### PR TITLE
Add structure folders with placeholder READMEs

### DIFF
--- a/ai-service/README.md
+++ b/ai-service/README.md
@@ -1,0 +1,2 @@
+# AI Service
+This folder will hold service components that interface with AI models.

--- a/app/README.md
+++ b/app/README.md
@@ -1,0 +1,2 @@
+# App
+This directory contains the core application code.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,2 @@
+# Documentation
+This directory will contain project documentation and guides.

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,0 +1,2 @@
+# Plugins
+This directory is for optional plugin modules that extend functionality.


### PR DESCRIPTION
## Summary
- add `app`, `ai-service`, `plugins`, and `docs` directories
- include placeholder README files explaining each folder

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6842697d82488323bbfa49470c67fdb0