### PR TITLE
Add local llama.cpp build scripts

### DIFF
--- a/ai-service/README.md
+++ b/ai-service/README.md
@@ -1,2 +1,5 @@
 # AI Service
-This folder will hold service components that interface with AI models.
+
+This folder holds service components that interface with AI models.
+
+- `local-model/` contains build scripts and instructions for running models locally with [llama.cpp](https://github.com/ggerganov/llama.cpp).

--- a/ai-service/local-model/README.md
+++ b/ai-service/local-model/README.md
@@ -1,0 +1,49 @@
+# Local Model Setup
+
+This folder contains simple build scripts for [llama.cpp](https://github.com/ggerganov/llama.cpp).
+
+## Building llama.cpp
+
+- `build_cpu.sh` builds llama.cpp for CPU usage only.
+- `build_gpu.sh` builds llama.cpp with CUDA support.
+
+Run the appropriate script from this directory:
+
+```bash
+./build_cpu.sh    # CPU build
+./build_gpu.sh    # GPU build with CUDA
+```
+
+The scripts clone the `llama.cpp` repository if it is not already present and then compile the project.
+
+## Downloading GGUF Models
+
+Create a `models` directory to store your models. GGUF files can be downloaded from providers such as Hugging Face. Example:
+
+```bash
+mkdir -p models
+wget https://example.com/path/to/model.gguf -O models/model.gguf
+```
+
+## Sample Manifest
+
+You can describe model locations and parameters in a `manifest.json` file:
+
+```json
+{
+  "models": [
+    {
+      "name": "llama-7b",
+      "path": "models/llama-7b.Q4_K_M.gguf",
+      "context_length": 4096,
+      "threads": 8,
+      "gpu_layers": 35
+    }
+  ]
+}
+```
+
+- `path` points to the GGUF model file.
+- `context_length` is the maximum number of tokens in the context window.
+- `threads` defines how many CPU threads to use.
+- `gpu_layers` sets how many layers will be offloaded to the GPU (set to `0` for CPU-only).

--- a/ai-service/local-model/build_cpu.sh
+++ b/ai-service/local-model/build_cpu.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+# Build llama.cpp with CPU support
+if [ ! -d llama.cpp ]; then
+  git clone https://github.com/ggerganov/llama.cpp.git
+fi
+cd llama.cpp
+make clean
+make

--- a/ai-service/local-model/build_gpu.sh
+++ b/ai-service/local-model/build_gpu.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+# Build llama.cpp with CUDA GPU acceleration
+if [ ! -d llama.cpp ]; then
+  git clone https://github.com/ggerganov/llama.cpp.git
+fi
+cd llama.cpp
+make clean
+make LLAMA_CUBLAS=1


### PR DESCRIPTION
## Summary
- add `local-model` subdirectory for llama.cpp
- provide build scripts for CPU and GPU versions
- document how to download GGUF models and use a manifest

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68426b4f120883238bfb2a5968a830e2