### PR TITLE
Resolve CI Node version conflict

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,14 +13,10 @@ jobs:
       - uses: actions/setup-git@v4
         with:
           lfs: true
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-node@v3
         with:
-          python-version: '3.x'
+          node-version: '18'
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install flake8 pytest
-      - name: Lint
-        run: flake8 .
+        run: npm install
       - name: Test
-        run: pytest -q
+        run: npm test


### PR DESCRIPTION
## Summary
- replace Python setup with Node in CI
- keep Git LFS step and run `npm install` and `npm test`

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68426eae28b483238f71af429143eedd

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update the CI workflow to use Node.js version 18 instead of Python, modifying the install and test steps to `npm install` and `npm test`.

### Why are these changes being made?

The changes resolve a conflict in the CI environment by aligning the configured runtime to match the project's requirements, as the project utilizes Node.js instead of Python. Switching to Node.js ensures the CI tasks accurately reflect the project's build and test processes.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->