### PR TITLE
feat: add API key validation to OpenRouter wrapper

### DIFF
--- a/ai-service/README.md
+++ b/ai-service/README.md
@@ -34,3 +34,7 @@ const { streamChatCompletion } = require('./openrouter');
   }
 })();
 ```
+
+The wrapper validates that an `OPENROUTER_API_KEY` value is provided. If the `apiKey`
+option is empty, `streamChatCompletion` throws an error before making any
+requests.

--- a/ai-service/openrouter.js
+++ b/ai-service/openrouter.js
@@ -13,6 +13,9 @@ const OPENROUTER_ENDPOINT = 'https://openrouter.ai/api/v1/chat/completions';
  * @returns {AsyncGenerator<Object>} async generator yielding completion deltas
  */
 async function* streamChatCompletion({ messages, models, apiKey }) {
+  if (!apiKey) {
+    throw new Error('OPENROUTER_API_KEY is required');
+  }
   if (!Array.isArray(models) || models.length === 0) {
     throw new Error('models must be a non-empty array');
   }


### PR DESCRIPTION
## Summary
- require `OPENROUTER_API_KEY` in `streamChatCompletion`
- document this validation in the OpenRouter README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68427073efb88323a55d7a4e4da537c5


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.
