### PR TITLE
Add test for missing OpenRouter apiKey

### DIFF
--- a/test/openrouter/stream.test.js
+++ b/test/openrouter/stream.test.js
@@ -48,4 +48,21 @@ describe('streamChatCompletion', () => {
       { choices: [{ delta: { content: 'bar' } }] }
     ]);
   });
+
+  it('throws when apiKey is missing', async () => {
+    let error;
+    try {
+      for await (const _ of streamChatCompletion({
+        messages: [],
+        models: ['model-a'],
+        apiKey: undefined
+      })) {
+        // no-op
+      }
+    } catch (err) {
+      error = err;
+    }
+    expect(error).to.be.instanceOf(Error);
+    expect(error.message).to.equal('OPENROUTER_API_KEY is required');
+  });
 });


### PR DESCRIPTION
## Summary
- add coverage for missing `apiKey` in `streamChatCompletion`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68427205fa408323ab4066d4262bdd9b


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.
