### PR TITLE
Fix fetch restoration in OpenRouter test

### DIFF
--- a/test/openrouter/stream.test.js
+++ b/test/openrouter/stream.test.js
@@ -2,7 +2,13 @@ const { streamChatCompletion } = require('../../ai-service/openrouter');
 const { ReadableStream } = require('node:stream/web');
 const { expect } = require('chai');
 
+// Preserve the original fetch implementation so it can be restored after tests
+const originalFetch = global.fetch;
+
 describe('streamChatCompletion', () => {
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
   function streamFromChunks(chunks) {
     return new ReadableStream({
       start(controller) {


### PR DESCRIPTION
## Summary
- keep the original `global.fetch` before stubbing it in tests
- restore `global.fetch` after each test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842720ad79083239536656a85640589

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Restore the original `fetch` implementation in the `OpenRouter` stream test using `afterEach` cleanup.

### Why are these changes being made?

The tests in `stream.test.js` modify the global `fetch` function, which could lead to side effects in other tests; restoring the original `fetch` ensures test isolation and consistency across test runs. This approach helps in maintaining the test environment’s integrity by making sure no global state is unintentionally altered.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->