### PR TITLE
Update README for Node and WebSocket polyfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ Alex 2.0 is a simple project used for demonstration purposes. This repository co
 
 ## Getting Started
 
-Make sure you have **Node.js v18 or higher** installed. The Node-based examples
-in this repository depend on features available in recent Node versions.
+Make sure you have **Node.js v18 or higher** installed. Node 18+ is required,
+and the `ws` package provides a WebSocket polyfill (loaded in
+`app/yjs-webrtc.js`) so the WebRTC examples work in a non-browser environment.
 
 1. Clone the repository and change into its directory:
    ```bash


### PR DESCRIPTION
## Summary
- document that the `ws` package polyfills `WebSocket`
- clarify that Node.js 18+ is required and the polyfill loads in `app/yjs-webrtc.js`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6842ecbcd63c8323bf03af92d0d84b68

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update the README to specify the requirement of Node.js v18+ and mention the use of the `ws` package as a WebSocket polyfill for running WebRTC examples outside the browser.

### Why are these changes being made?

This change provides clarity on the Node.js version requirement and the integration of the `ws` package, ensuring that users understand the setup needed to run the WebRTC examples correctly in non-browser environments. This helps users configure their environment appropriately and prevents potential confusion or setup issues.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->