### PR TITLE
Implement simple task planner agent

### DIFF
--- a/agent/task-planner.js
+++ b/agent/task-planner.js
@@ -1,0 +1,40 @@
+const { streamChatCompletion } = require('../ai-service/openrouter')
+
+async function plan(goal, { streamChatCompletion: stream = streamChatCompletion } = {}) {
+  const apiKey = process.env.OPENROUTER_API_KEY
+  if (!goal) throw new Error('goal is required')
+  if (!apiKey) throw new Error('OPENROUTER_API_KEY is not set')
+
+  const messages = [
+    { role: 'system', content: 'You are a helpful assistant that breaks a goal into a numbered step-by-step plan.' },
+    { role: 'user', content: `Goal: ${goal}` }
+  ]
+
+  let result = ''
+  for await (const delta of stream({
+    messages,
+    models: ['openrouter/openai/gpt-3.5-turbo'],
+    apiKey
+  })) {
+    const content = delta.choices?.[0]?.delta?.content
+    if (content) result += content
+  }
+  return result.trim()
+}
+
+async function main() {
+  const goal = process.argv.slice(2).join(' ')
+  try {
+    const output = await plan(goal)
+    console.log(output)
+  } catch (err) {
+    console.error(err.message)
+    process.exit(1)
+  }
+}
+
+if (require.main === module) {
+  main()
+}
+
+module.exports = { plan }

--- a/docs/ISSUES.md
+++ b/docs/ISSUES.md
@@ -17,7 +17,7 @@ This file lists proposed epics and issues for delivering the AI IDE.
   - Acceptance: CI installs dependencies and runs tests.
 
 ## Epic: Autonomous Agent
-- **Issue: Task Planner**
+- **Issue: Task Planner** ✅
   - Accept user goal and produce step-by-step plan.
   - Acceptance: Plan printed to log.
 - **Issue: File Editor**

--- a/test/agent/task-planner.test.js
+++ b/test/agent/task-planner.test.js
@@ -1,0 +1,32 @@
+const { expect } = require('chai')
+const { plan } = require('../../agent/task-planner')
+
+function mockStream(chunks) {
+  return (async function* () {
+    for (const content of chunks) {
+      yield { choices: [{ delta: { content } }] }
+    }
+  })()
+}
+
+describe('plan', () => {
+  it('returns concatenated plan from stream', async () => {
+    process.env.OPENROUTER_API_KEY = 'test'
+    const result = await plan('build feature', {
+      streamChatCompletion: () => mockStream(['1. a', '\n2. b'])
+    })
+    expect(result).to.equal('1. a\n2. b')
+  })
+
+  it('throws when API key missing', async () => {
+    delete process.env.OPENROUTER_API_KEY
+    let err
+    try {
+      await plan('goal', { streamChatCompletion: () => mockStream([]) })
+    } catch (e) {
+      err = e
+    }
+    expect(err).to.be.instanceOf(Error)
+    expect(err.message).to.equal('OPENROUTER_API_KEY is not set')
+  })
+})


### PR DESCRIPTION
## Summary
- implement a basic task planner agent that streams a step-by-step plan
- mark Task Planner issue as complete
- add tests for planner

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68437f7cdde08323b25eacd3aa94d26f

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Implement a simple task planner agent that breaks down a user-provided goal into a step-by-step plan using AI-based text completion, and add corresponding tests and documentation updates.

### Why are these changes being made?

To automate the creation of a task plan by leveraging AI capabilities, aiming to improve user productivity by providing structured steps for achieving goals. This approach validates user input, utilizes the OpenAI API for generating plans, and addresses potential errors such as missing API keys, ensuring robustness.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->