### PR TITLE
Implement presence cursors

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The current structure is intentionally lightweight. It includes only a README fi
 
 ## Real-time Editing Demo
 
-The `app` folder now contains a small module for initializing a [Yjs](https://yjs.dev/) document using the WebRTC provider. A helper binds the shared document to the Monaco editor.
+The `app` folder now contains a small module for initializing a [Yjs](https://yjs.dev/) document using the WebRTC provider. A helper binds the shared document to the Monaco editor and exposes remote cursor presence.
 
 Run a manual sync test to see two peers share text data:
 

--- a/app/README.md
+++ b/app/README.md
@@ -15,4 +15,5 @@ npm test
 ```
 
 The test creates two peers in the same process. Text inserted on one peer is
-synced to the other peer via WebRTC.
+synced to the other peer via WebRTC. Remote cursor positions appear with the
+peer's name and a unique colour.

--- a/app/monaco-shared.js
+++ b/app/monaco-shared.js
@@ -11,6 +11,7 @@ const monaco = require('monaco-editor')
  */
 function createSharedMonaco(element, room = 'monaco-room') {
   const { doc, provider } = initYjs(room)
+  const { awareness } = provider
   const yText = doc.getText('monaco')
   const model = monaco.editor.createModel('', 'javascript')
   const editor = monaco.editor.create(element, {
@@ -18,7 +19,53 @@ function createSharedMonaco(element, room = 'monaco-room') {
     language: 'javascript',
     theme: 'vs-dark',
   })
-  new MonacoBinding(yText, model, new Set([editor]), provider.awareness)
+
+  // assign random user colour and name for presence
+  const user = {
+    name: `User-${doc.clientID}`,
+    color: `#${Math.floor(Math.random() * 0xffffff).toString(16).padStart(6, '0')}`
+  }
+  awareness.setLocalStateField('user', user)
+
+  const applyStyles = (clientId, info) => {
+    if (!info || !info.color || !info.name) return
+    const id = `yjs-style-${clientId}`
+    let style = document.getElementById(id)
+    if (!style) {
+      style = document.createElement('style')
+      style.id = id
+      document.head.appendChild(style)
+    }
+    style.textContent = `
+      .yRemoteSelection-${clientId} { background-color: ${info.color}33; }
+      .yRemoteSelectionHead-${clientId} { border-left: 2px solid ${info.color}; position: relative; }
+      .yRemoteSelectionHead-${clientId}::after {
+        content: '${info.name}';
+        position: absolute;
+        top: -1.2em;
+        left: 0;
+        background: ${info.color};
+        color: white;
+        font-size: 0.75em;
+        padding: 2px 4px;
+        border-radius: 4px;
+        white-space: nowrap;
+      }
+    `
+  }
+
+  // apply styles for existing peers and listen for new ones
+  awareness.getStates().forEach((state, id) => {
+    if (id !== doc.clientID) applyStyles(id, state.user)
+  })
+  awareness.on('update', ({ added, updated }) => {
+    const states = awareness.getStates()
+    for (const id of [...added, ...updated]) {
+      if (id !== doc.clientID) applyStyles(id, states.get(id).user)
+    }
+  })
+
+  new MonacoBinding(yText, model, new Set([editor]), awareness)
   return { editor, provider }
 }
 

--- a/docs/ISSUES.md
+++ b/docs/ISSUES.md
@@ -28,10 +28,10 @@ This file lists proposed epics and issues for delivering the AI IDE.
   - Acceptance: Tests pass before PR is created.
 
 ## Epic: Collaboration
-- **Issue: Yjs Sync**
+- **Issue: Yjs Sync** ✅
   - Connect multiple peers using WebRTC provider.
   - Acceptance: Text edits propagate between two windows.
-- **Issue: Presence Cursors**
+- **Issue: Presence Cursors** ✅
   - Display remote cursor positions.
   - Acceptance: See name/colour of remote user.
 


### PR DESCRIPTION
## Summary
- support awareness-based cursor presence in the shared Monaco editor
- document remote cursor feature
- mark collaboration issues as complete

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843830aa6a08323aaf830baca3b66af

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Implement remote cursor presence in the Monaco editor using Yjs, displaying each peer's cursor position with a unique color and name.

### Why are these changes being made?

These changes enhance the real-time collaborative editing experience by visually distinguishing each user's cursor, helping users identify who is editing which part of the document. The implementation uses random color assignment and unique user identifiers to ensure clarity and prevent any potential confusion during concurrent editing sessions.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->