### PR TITLE
Add inline autocomplete with OpenRouter

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ npm test
 
 The test script spawns two Node processes that connect to the public signaling server. One inserts text and the other prints the synchronized content.
 
+Press `Ctrl+Space` in the editor to request an inline completion from the OpenRouter API. The suggestion appears directly at the cursor location.
+
 ## Contributing
 
 Contributions are welcome! Fork the repository, create a new branch for your feature or bug fix, and submit a pull request. Please keep your commits concise and provide clear descriptions of your changes.

--- a/app/autocomplete.js
+++ b/app/autocomplete.js
@@ -1,0 +1,53 @@
+const { streamChatCompletion } = require('../ai-service/openrouter');
+
+async function fetchCompletion(prefix, { streamChatCompletion: stream = streamChatCompletion } = {}) {
+  const apiKey = process.env.OPENROUTER_API_KEY;
+  if (!apiKey) throw new Error('OPENROUTER_API_KEY is not set');
+  const messages = [{ role: 'user', content: prefix }];
+  let result = '';
+  for await (const chunk of stream({
+    messages,
+    models: ['openrouter/openai/gpt-3.5-turbo'],
+    apiKey
+  })) {
+    const content = chunk.choices?.[0]?.delta?.content;
+    if (content) result += content;
+  }
+  return result.trim();
+}
+
+function enableInlineCompletion(editor) {
+  const monaco = require('monaco-editor');
+  const provider = {
+    async provideInlineCompletions(model, position) {
+      const prefix = model.getValueInRange({
+        startLineNumber: 1,
+        startColumn: 1,
+        endLineNumber: position.lineNumber,
+        endColumn: position.column
+      });
+      try {
+        const text = await fetchCompletion(prefix);
+        if (!text) return { items: [] };
+        return {
+          items: [
+            {
+              insertText: text,
+              range: new monaco.Range(position.lineNumber, position.column, position.lineNumber, position.column),
+            }
+          ]
+        };
+      } catch {
+        return { items: [] };
+      }
+    },
+    freeInlineCompletions() {}
+  };
+  monaco.languages.registerInlineCompletionsProvider('javascript', provider);
+
+  editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.Space, () => {
+    editor.trigger('keyboard', 'inlineSuggest.trigger', {});
+  });
+}
+
+module.exports = { fetchCompletion, enableInlineCompletion };

--- a/app/src/index.html
+++ b/app/src/index.html
@@ -19,9 +19,11 @@
   <script>
     const { runChat } = require('../chat');
     const { createSharedMonaco } = require('../monaco-shared');
+    const { enableInlineCompletion } = require('../autocomplete');
     require.config({ paths: { 'vs': 'https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.44.0/min/vs' } });
     require(['vs/editor/editor.main'], function() {
       const { editor } = createSharedMonaco(document.getElementById('container'));
+      enableInlineCompletion(editor);
 
       document.getElementById('chat-send').onclick = async () => {
         const input = document.getElementById('chat-input');

--- a/test/app/autocomplete.test.js
+++ b/test/app/autocomplete.test.js
@@ -1,0 +1,32 @@
+const { expect } = require('chai');
+const { fetchCompletion } = require('../../app/autocomplete');
+
+function mockStream(chunks) {
+  return (async function* () {
+    for (const c of chunks) {
+      yield { choices: [{ delta: { content: c } }] };
+    }
+  })();
+}
+
+describe('fetchCompletion', () => {
+  it('concatenates streamed chunks', async () => {
+    process.env.OPENROUTER_API_KEY = 'test';
+    const result = await fetchCompletion('foo', {
+      streamChatCompletion: () => mockStream(['bar', ' baz'])
+    });
+    expect(result).to.equal('bar baz');
+  });
+
+  it('throws when API key missing', async () => {
+    delete process.env.OPENROUTER_API_KEY;
+    let err;
+    try {
+      await fetchCompletion('foo', { streamChatCompletion: () => mockStream([]) });
+    } catch (e) {
+      err = e;
+    }
+    expect(err).to.be.instanceOf(Error);
+    expect(err.message).to.equal('OPENROUTER_API_KEY is not set');
+  });
+});


### PR DESCRIPTION
## Summary
- add an `autocomplete` helper for fetching completions and wiring them into Monaco
- enable inline completion in the demo app
- document the `Ctrl+Space` shortcut
- test the new `fetchCompletion` helper

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6843849155c88323939c7a02ff24a640

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add inline autocomplete functionality using the OpenRouter API to provide real-time code suggestions in the editor.

### Why are these changes being made?

This update enhances the coding experience by integrating the OpenRouter API, which offers inline code completions similar to those found in modern IDEs, thereby boosting productivity and improving the user experience. This approach was chosen as OpenRouter provides a reliable and scalable API for fetching intelligent code suggestions, and the implementation effectively leverages existing libraries such as `monaco-editor`.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->