### PR TITLE
Add plugin loader

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,2 +1,8 @@
 # Plugins
 This directory is for optional plugin modules that extend functionality.
+
+A plugin exports an `activate(context)` function. The context object is shared
+with all plugins and can expose APIs or configuration.
+
+Use `loadPlugins(dir, context)` from `plugins/loader.js` to load all plugins in a
+directory.

--- a/plugins/loader.js
+++ b/plugins/loader.js
@@ -1,0 +1,25 @@
+const { readdirSync } = require('fs');
+const { join } = require('path');
+
+/**
+ * Load all plugin modules from a directory and invoke their `activate`
+ * functions if present.
+ *
+ * @param {string} dir Directory containing plugin modules
+ * @param {object} [context] Optional context passed to each plugin
+ * @returns {object[]} Array of loaded plugin modules
+ */
+function loadPlugins(dir, context = {}) {
+  const modules = [];
+  for (const file of readdirSync(dir)) {
+    if (!file.endsWith('.js')) continue;
+    const mod = require(join(dir, file));
+    if (typeof mod.activate === 'function') {
+      mod.activate(context);
+    }
+    modules.push(mod);
+  }
+  return modules;
+}
+
+module.exports = { loadPlugins };

--- a/test/plugins/loader.test.js
+++ b/test/plugins/loader.test.js
@@ -1,0 +1,24 @@
+const { expect } = require('chai');
+const fs = require('fs');
+const os = require('os');
+const { join } = require('path');
+const { loadPlugins } = require('../../plugins/loader');
+
+describe('loadPlugins', () => {
+  it('calls activate on each plugin', () => {
+    const dir = fs.mkdtempSync(join(os.tmpdir(), 'plugins-'));
+    fs.writeFileSync(join(dir, 'a.js'), 'module.exports.activate = ctx => { ctx.a = true; };');
+    const context = {};
+    loadPlugins(dir, context);
+    expect(context.a).to.equal(true);
+  });
+
+  it('loads modules without activate', () => {
+    const dir = fs.mkdtempSync(join(os.tmpdir(), 'plugins-'));
+    fs.writeFileSync(join(dir, 'b.js'), 'module.exports = { name: "b" };');
+    const context = {};
+    const mods = loadPlugins(dir, context);
+    expect(mods).to.have.length(1);
+    expect(mods[0].name).to.equal('b');
+  });
+});


### PR DESCRIPTION
## Summary
- load plugins from a directory
- document simple plugin API
- test plugin loader

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68440d04dc6883238d81a4f1e970e6a0

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a plugin loader function to load and activate plugins from a specified directory, along with tests for this functionality.

### Why are these changes being made?

These changes are implemented to facilitate extending the application's functionality through modular plugin components. By providing a loader function that handles plugin activation and context sharing, the system can dynamically incorporate and manage plugins efficiently. The associated tests ensure that plugins are loaded correctly and their `activate` methods are invoked as expected.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->