### PR TITLE
Implement persistent memory store

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,12 @@ Each OpenRouter request can include `usage` tracking to report token counts and 
 The `cost-dashboard` module aggregates these usage objects and exposes the total
 credits consumed during a session.
 
+## Persistent Memory Store
+
+Use `memory-store.js` to persist conversation history between sessions. The
+module provides `append(entry, file)` to record messages, `load(file)` to read
+them back, and `reset(file)` to clear the store.
+
 ## Contributing
 
 Contributions are welcome! Fork the repository, create a new branch for your feature or bug fix, and submit a pull request. Please keep your commits concise and provide clear descriptions of your changes.

--- a/ai-service/memory-store.js
+++ b/ai-service/memory-store.js
@@ -1,0 +1,36 @@
+const { readFileSync, writeFileSync, existsSync } = require('fs');
+
+/**
+ * Load persisted memory from a JSON file.
+ * @param {string} [file='memory.json'] Path to the JSON file.
+ * @returns {object[]} Array of stored entries.
+ */
+function load(file = 'memory.json') {
+  if (!existsSync(file)) return [];
+  try {
+    return JSON.parse(readFileSync(file, 'utf8'));
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Append an entry to the memory file.
+ * @param {object} entry Entry to persist.
+ * @param {string} [file='memory.json'] Path to the JSON file.
+ */
+function append(entry, file = 'memory.json') {
+  const data = load(file);
+  data.push(entry);
+  writeFileSync(file, JSON.stringify(data, null, 2));
+}
+
+/**
+ * Clear all entries from the memory file.
+ * @param {string} [file='memory.json'] Path to the JSON file.
+ */
+function reset(file = 'memory.json') {
+  writeFileSync(file, '[]');
+}
+
+module.exports = { load, append, reset };

--- a/docs/ISSUES.md
+++ b/docs/ISSUES.md
@@ -40,3 +40,8 @@ This file lists proposed epics and issues for delivering the AI IDE.
   - Bundle GGUF weights and `llama.cpp` binaries.
   - Acceptance: Autocomplete works offline.
 
+## Epic: Data Persistence
+- **Issue: Persistent Memory Store** ✅
+  - Save conversation history to disk and reload it on startup.
+  - Acceptance: Messages appended to the store persist across sessions.
+

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -24,7 +24,7 @@ This document outlines the proposed plan for developing the AI IDE.
 3. **v1.0 (12 wks)**
    - Local model runner integration
    - Extension marketplace and plugin API
-   - Persistent memory store
+   - Persistent memory store ✅
 4. **v1.1+**
    - Voice coding
    - Multi-agent code review

--- a/test/ai-service/memory-store.test.js
+++ b/test/ai-service/memory-store.test.js
@@ -1,0 +1,28 @@
+const { expect } = require('chai');
+const fs = require('fs');
+const os = require('os');
+const { join } = require('path');
+const { load, append, reset } = require('../../ai-service/memory-store');
+
+describe('memory store', () => {
+  let file;
+  beforeEach(() => {
+    file = join(fs.mkdtempSync(join(os.tmpdir(), 'mem-')), 'mem.json');
+  });
+
+  it('returns empty array when file missing', () => {
+    expect(load(file)).to.deep.equal([]);
+  });
+
+  it('appends entries and persists them', () => {
+    append({ msg: 'a' }, file);
+    append({ msg: 'b' }, file);
+    expect(load(file)).to.deep.equal([{ msg: 'a' }, { msg: 'b' }]);
+  });
+
+  it('resets the file', () => {
+    append({ msg: 'a' }, file);
+    reset(file);
+    expect(load(file)).to.deep.equal([]);
+  });
+});


### PR DESCRIPTION
## Summary
- implement memory-store module for saving conversation history
- document new memory store feature
- mark roadmap and issues as completed for persistent memory
- add tests for memory-store

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68440ee0a12c83239053d12903aa05b6

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Implement and document a persistent memory store for saving and retrieving conversation history across sessions using `memory-store.js`, along with accompanying tests.

### Why are these changes being made?

These changes provide a way to maintain conversation history by persisting data to disk, which allows for continuity between sessions. This implementation solves the issue of data loss on shutdown and aligns with the roadmap and issue guidelines by ensuring that messages are reliably saved and reloaded.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->