### PR TITLE
Add local model fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ export LLAMA_MODEL=/path/to/model.gguf
 ```
 
 The `runLlama` helper in `ai-service/llama.js` executes the binary and returns the generated text.
+If `OPENROUTER_API_KEY` is unset and these variables are provided, the app automatically falls back to the local runner.
 
 ## Cost Dashboard
 

--- a/app/autocomplete.js
+++ b/app/autocomplete.js
@@ -1,19 +1,25 @@
 const { streamChatCompletion } = require('../ai-service/openrouter');
+const { runLlama } = require('../ai-service/llama');
 
-async function fetchCompletion(prefix, { streamChatCompletion: stream = streamChatCompletion } = {}) {
+async function fetchCompletion(prefix, { streamChatCompletion: stream = streamChatCompletion, runLlama: llama = runLlama } = {}) {
   const apiKey = process.env.OPENROUTER_API_KEY;
-  if (!apiKey) throw new Error('OPENROUTER_API_KEY is not set');
   const messages = [{ role: 'user', content: prefix }];
-  let result = '';
-  for await (const chunk of stream({
-    messages,
-    models: ['openrouter/openai/gpt-3.5-turbo'],
-    apiKey
-  })) {
-    const content = chunk.choices?.[0]?.delta?.content;
-    if (content) result += content;
+  if (apiKey) {
+    let result = '';
+    for await (const chunk of stream({
+      messages,
+      models: ['openrouter/openai/gpt-3.5-turbo'],
+      apiKey
+    })) {
+      const content = chunk.choices?.[0]?.delta?.content;
+      if (content) result += content;
+    }
+    return result.trim();
   }
-  return result.trim();
+  if (process.env.LLAMA_PATH && process.env.LLAMA_MODEL) {
+    return llama(prefix);
+  }
+  throw new Error('OPENROUTER_API_KEY is not set');
 }
 
 function enableInlineCompletion(editor) {

--- a/app/chat.js
+++ b/app/chat.js
@@ -1,18 +1,26 @@
 const { streamChatCompletion } = require('../ai-service/openrouter');
+const { runLlama } = require('../ai-service/llama');
 
-async function runChat(messages, onToken) {
+async function runChat(messages, onToken, { streamChatCompletion: stream = streamChatCompletion, runLlama: llama = runLlama } = {}) {
   const apiKey = process.env.OPENROUTER_API_KEY;
-  if (!apiKey) {
-    throw new Error('OPENROUTER_API_KEY is not set');
+  if (apiKey) {
+    for await (const chunk of stream({
+      messages,
+      models: ['openrouter/openai/gpt-3.5-turbo'],
+      apiKey
+    })) {
+      const content = chunk.choices?.[0]?.delta?.content;
+      if (content) onToken(content);
+    }
+    return;
   }
-  for await (const chunk of streamChatCompletion({
-    messages,
-    models: ['openrouter/openai/gpt-3.5-turbo'],
-    apiKey
-  })) {
-    const content = chunk.choices?.[0]?.delta?.content;
-    if (content) onToken(content);
+  if (process.env.LLAMA_PATH && process.env.LLAMA_MODEL) {
+    const prompt = messages.map(m => m.content).join('\n');
+    const text = await llama(prompt);
+    onToken(text);
+    return;
   }
+  throw new Error('OPENROUTER_API_KEY is not set');
 }
 
 module.exports = { runChat };

--- a/test/app/autocomplete.test.js
+++ b/test/app/autocomplete.test.js
@@ -18,8 +18,10 @@ describe('fetchCompletion', () => {
     expect(result).to.equal('bar baz');
   });
 
-  it('throws when API key missing', async () => {
+  it('throws when API key missing and no local model', async () => {
     delete process.env.OPENROUTER_API_KEY;
+    delete process.env.LLAMA_PATH;
+    delete process.env.LLAMA_MODEL;
     let err;
     try {
       await fetchCompletion('foo', { streamChatCompletion: () => mockStream([]) });
@@ -28,5 +30,15 @@ describe('fetchCompletion', () => {
     }
     expect(err).to.be.instanceOf(Error);
     expect(err.message).to.equal('OPENROUTER_API_KEY is not set');
+  });
+
+  it('falls back to local model when API key missing', async () => {
+    delete process.env.OPENROUTER_API_KEY;
+    process.env.LLAMA_PATH = '/bin/llama';
+    process.env.LLAMA_MODEL = 'model.gguf';
+    const result = await fetchCompletion('foo', {
+      runLlama: async () => 'local'
+    });
+    expect(result).to.equal('local');
   });
 });


### PR DESCRIPTION
## Summary
- integrate llama.cpp runner with chat and autocomplete
- fall back to local models when OPENROUTER_API_KEY is unset
- document offline fallback in README
- test autocomplete fallback logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68441084282883239e56f631a8e26221

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Implement a local model fallback in the autocomplete and chat functions, enabling the code to use a local model when the `OPENROUTER_API_KEY` is unset.

### Why are these changes being made?

These changes address the problem of relying solely on a remote API by adding the capability to invoke a local model if the API key is missing. This improves the application's robustness and accessibility by ensuring operations can continue with locally available resources when remote services are not accessible.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->