### PR TITLE
Implement extension marketplace and plugin API

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -23,7 +23,7 @@ This document outlines the proposed plan for developing the AI IDE.
    - Real-time collaboration via Yjs ✅
 3. **v1.0 (12 wks)**
    - Local model runner integration
-   - Extension marketplace and plugin API
+   - Extension marketplace and plugin API ✅
    - Persistent memory store ✅
 4. **v1.1+**
    - Voice coding

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -2,7 +2,11 @@
 This directory is for optional plugin modules that extend functionality.
 
 A plugin exports an `activate(context)` function. The context object is shared
-with all plugins and can expose APIs or configuration.
+with all plugins and exposes the plugin API.
 
 Use `loadPlugins(dir, context)` from `plugins/loader.js` to load all plugins in a
-directory.
+directory. The default API in `plugins/api.js` lets plugins register commands
+via `registerCommand(name, fn)` and execute them with `runCommand(name, ...args)`.
+
+Available extensions can be listed and installed using `marketplace.js`, which
+reads `marketplace.json` for plugin sources.

--- a/plugins/api.js
+++ b/plugins/api.js
@@ -1,0 +1,22 @@
+const commands = {};
+
+function resetCommands() {
+  for (const key of Object.keys(commands)) {
+    delete commands[key];
+  }
+}
+
+function registerCommand(name, fn) {
+  if (typeof name !== 'string' || typeof fn !== 'function') {
+    throw new Error('registerCommand(name, fn)');
+  }
+  commands[name] = fn;
+}
+
+function runCommand(name, ...args) {
+  const cmd = commands[name];
+  if (!cmd) throw new Error(`Command ${name} not found`);
+  return cmd(...args);
+}
+
+module.exports = { registerCommand, runCommand, resetCommands };

--- a/plugins/hello.js
+++ b/plugins/hello.js
@@ -1,0 +1,5 @@
+function activate({ registerCommand }) {
+  registerCommand('hello', () => 'Hello from plugin!');
+}
+
+module.exports = { activate };

--- a/plugins/marketplace.js
+++ b/plugins/marketplace.js
@@ -1,0 +1,37 @@
+const { readFileSync, writeFileSync } = require('fs');
+const { join } = require('path');
+const https = require('https');
+
+function loadRegistry(file = join(__dirname, 'marketplace.json')) {
+  return JSON.parse(readFileSync(file, 'utf8'));
+}
+
+function list(file) {
+  return Object.keys(loadRegistry(file));
+}
+
+function defaultDownload(url) {
+  return new Promise((resolve, reject) => {
+    https
+      .get(url, res => {
+        if (res.statusCode !== 200) {
+          reject(new Error(`HTTP ${res.statusCode}`));
+          return;
+        }
+        let data = '';
+        res.on('data', chunk => (data += chunk));
+        res.on('end', () => resolve(data));
+      })
+      .on('error', reject);
+  });
+}
+
+async function install(name, { marketplaceFile, dir = __dirname, download = defaultDownload } = {}) {
+  const registry = loadRegistry(marketplaceFile);
+  const url = registry[name];
+  if (!url) throw new Error(`Unknown plugin: ${name}`);
+  const code = await download(url);
+  writeFileSync(join(dir, `${name}.js`), code);
+}
+
+module.exports = { list, install };

--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -1,0 +1,3 @@
+{
+  "hello": "https://example.com/hello.js"
+}

--- a/test/plugins/api.test.js
+++ b/test/plugins/api.test.js
@@ -1,0 +1,21 @@
+const { expect } = require('chai');
+const fs = require('fs');
+const os = require('os');
+const { join } = require('path');
+const { loadPlugins } = require('../../plugins/loader');
+const api = require('../../plugins/api');
+
+describe('plugin api', () => {
+  afterEach(() => api.resetCommands());
+
+  it('registers commands from plugin', () => {
+    const dir = fs.mkdtempSync(join(os.tmpdir(), 'plug-'));
+    fs.writeFileSync(
+      join(dir, 'p.js'),
+      'module.exports.activate = ({registerCommand}) => registerCommand("hi", () => "ok");'
+    );
+    loadPlugins(dir, api);
+    const result = api.runCommand('hi');
+    expect(result).to.equal('ok');
+  });
+});

--- a/test/plugins/marketplace.test.js
+++ b/test/plugins/marketplace.test.js
@@ -1,0 +1,26 @@
+const { expect } = require('chai');
+const fs = require('fs');
+const os = require('os');
+const { join } = require('path');
+const { list, install } = require('../../plugins/marketplace');
+
+describe('marketplace', () => {
+  it('lists plugin names', () => {
+    const dir = fs.mkdtempSync(join(os.tmpdir(), 'mp-'));
+    const file = join(dir, 'market.json');
+    fs.writeFileSync(file, JSON.stringify({ foo: 'http://example.com/foo.js' }));
+    const names = list(file);
+    expect(names).to.deep.equal(['foo']);
+  });
+
+  it('installs plugin using custom downloader', async () => {
+    const dir = fs.mkdtempSync(join(os.tmpdir(), 'mp-'));
+    const file = join(dir, 'market.json');
+    fs.writeFileSync(file, JSON.stringify({ bar: 'http://example.com/bar.js' }));
+    const dest = fs.mkdtempSync(join(os.tmpdir(), 'plug-'));
+    const download = async url => `module.exports.name = '${url}';`;
+    await install('bar', { marketplaceFile: file, dir: dest, download });
+    const code = fs.readFileSync(join(dest, 'bar.js'), 'utf8');
+    expect(code).to.contain('example.com/bar.js');
+  });
+});


### PR DESCRIPTION
## Summary
- create plugin API with command registry
- provide marketplace utilities for listing and installing plugins
- ship example `hello` plugin and registry file
- document plugin usage and update roadmap milestone
- test plugin API and marketplace modules

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68441534b6a083238025029bfd6e8cfa

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Implement the extension marketplace and plugin API by adding the ability to register and execute commands through plugins, and enabling the listing and installation of plugins from a marketplace.

### Why are these changes being made?

These changes are being made to expand the functionality of the software by allowing external modules to extend capabilities using plugins. This implementation offers a streamlined mechanism to load, register, and execute plugin commands, which enhances user flexibility. Additionally, the marketplace setup allows users to easily discover, list, and install plugins, promoting an ecosystem of modular extensions.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->