### PR TITLE
Add chat fallback test

### DIFF
--- a/test/app/chat.test.js
+++ b/test/app/chat.test.js
@@ -1,0 +1,50 @@
+const { expect } = require('chai');
+const { runChat } = require('../../app/chat');
+
+function mockStream(chunks) {
+  return (async function* () {
+    for (const c of chunks) {
+      yield { choices: [{ delta: { content: c } }] };
+    }
+  })();
+}
+
+describe('runChat', () => {
+  it('streams tokens from OpenRouter', async () => {
+    process.env.OPENROUTER_API_KEY = 'test';
+    const received = [];
+    await runChat([
+      { role: 'user', content: 'hi' }
+    ], (t) => received.push(t), {
+      streamChatCompletion: () => mockStream(['a', 'b'])
+    });
+    expect(received.join('')).to.equal('ab');
+  });
+
+  it('throws when API key missing and no local model', async () => {
+    delete process.env.OPENROUTER_API_KEY;
+    delete process.env.LLAMA_PATH;
+    delete process.env.LLAMA_MODEL;
+    let err;
+    try {
+      await runChat([], () => {}, { streamChatCompletion: () => mockStream([]) });
+    } catch (e) {
+      err = e;
+    }
+    expect(err).to.be.instanceOf(Error);
+    expect(err.message).to.equal('OPENROUTER_API_KEY is not set');
+  });
+
+  it('falls back to local model when API key missing', async () => {
+    delete process.env.OPENROUTER_API_KEY;
+    process.env.LLAMA_PATH = '/bin/llama';
+    process.env.LLAMA_MODEL = 'model.gguf';
+    const received = [];
+    await runChat([
+      { role: 'user', content: 'hi' }
+    ], (t) => received.push(t), {
+      runLlama: async () => 'local'
+    });
+    expect(received.join('')).to.equal('local');
+  });
+});


### PR DESCRIPTION
## Summary
- add unit test for `runChat` offline fallback

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68441ad3bce48323a44159a82b4e1c48

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add unit tests for the `runChat` function to verify its behavior under various conditions including streaming tokens using `OpenRouter`, handling missing API keys, and falling back to a local model.

### Why are these changes being made?

These changes ensure that the `runChat` function works as expected in scenarios where the `OpenRouter` API key is present, missing, or falls back on a local model when no API key is set. This is crucial for maintaining the reliability and correctness of the chat application, especially in testing environments.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->