### PR TITLE
Start next roadmap task

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,14 @@ export LLAMA_MODEL=/path/to/model.gguf
 The `runLlama` helper in `ai-service/llama.js` executes the binary and returns the generated text.
 If `OPENROUTER_API_KEY` is unset and these variables are provided, the app automatically falls back to the local runner.
 
+## Voice Coding
+
+Alex 2.0 can capture speech and insert the transcribed text directly into the editor.
+The `createVoiceCoder` function in `app/voice.js` wraps the browser's
+`SpeechRecognition` API. Pass the active Monaco editor to
+`createVoiceCoder(editor)` and call `start()` to begin dictation. Call `stop()`
+to end the session. Spoken words appear at the current cursor position.
+
 ## Cost Dashboard
 
 Each OpenRouter request can include `usage` tracking to report token counts and cost.

--- a/app/src/index.html
+++ b/app/src/index.html
@@ -9,21 +9,39 @@
 </head>
 <body>
   <div id="container"></div>
-  <div style="position:absolute;bottom:0;width:100%;background:#222;color:#eee;padding:4px;">
-    <input id="chat-input" style="width:80%" placeholder="Ask the assistant" />
-    <button id="chat-send">Send</button>
-    <pre id="chat-output" style="white-space:pre-wrap;"></pre>
-  </div>
+    <div style="position:absolute;bottom:0;width:100%;background:#222;color:#eee;padding:4px;">
+      <input id="chat-input" style="width:70%" placeholder="Ask the assistant" />
+      <button id="chat-send">Send</button>
+      <button id="voice-btn">Voice</button>
+      <pre id="chat-output" style="white-space:pre-wrap;"></pre>
+    </div>
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.44.0/min/vs/loader.min.js"></script>
   <script>
     const { runChat } = require('../chat');
-    const { createSharedMonaco } = require('../monaco-shared');
-    const { enableInlineCompletion } = require('../autocomplete');
-    require.config({ paths: { 'vs': 'https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.44.0/min/vs' } });
-    require(['vs/editor/editor.main'], function() {
-      const { editor } = createSharedMonaco(document.getElementById('container'));
-      enableInlineCompletion(editor);
+      const { createSharedMonaco } = require('../monaco-shared');
+      const { enableInlineCompletion } = require('../autocomplete');
+      const { createVoiceCoder } = require('../voice');
+      require.config({ paths: { 'vs': 'https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.44.0/min/vs' } });
+      require(['vs/editor/editor.main'], function() {
+        const { editor } = createSharedMonaco(document.getElementById('container'));
+        enableInlineCompletion(editor);
+        let voice;
+        document.getElementById('voice-btn').onclick = () => {
+          if (!voice) {
+            try {
+              voice = createVoiceCoder(editor);
+              voice.start();
+              document.getElementById('voice-btn').textContent = 'Stop';
+            } catch (err) {
+              alert(err.message);
+            }
+          } else {
+            voice.stop();
+            voice = null;
+            document.getElementById('voice-btn').textContent = 'Voice';
+          }
+        };
 
       document.getElementById('chat-send').onclick = async () => {
         const input = document.getElementById('chat-input');

--- a/app/voice.js
+++ b/app/voice.js
@@ -1,0 +1,30 @@
+function createVoiceCoder(editor, RecognitionCtor) {
+  if (!RecognitionCtor) {
+    const SpeechRecognition = (typeof window !== 'undefined') && (window.SpeechRecognition || window.webkitSpeechRecognition);
+    RecognitionCtor = SpeechRecognition;
+  }
+  if (!RecognitionCtor) {
+    throw new Error('SpeechRecognition not supported');
+  }
+  const recognition = new RecognitionCtor();
+  recognition.continuous = true;
+  recognition.interimResults = false;
+
+  recognition.onresult = event => {
+    let text = '';
+    for (const res of event.results) {
+      if (res[0] && res[0].transcript) {
+        text += res[0].transcript;
+      }
+    }
+    const range = editor.getSelection();
+    editor.executeEdits(null, [{ range, text, forceMoveMarkers: true }]);
+  };
+
+  return {
+    start() { recognition.start(); },
+    stop() { recognition.stop(); }
+  };
+}
+
+module.exports = { createVoiceCoder };

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -22,11 +22,11 @@ This document outlines the proposed plan for developing the AI IDE.
    - Cost dashboard with OpenRouter headers ✅
    - Real-time collaboration via Yjs ✅
 3. **v1.0 (12 wks)**
-   - Local model runner integration
+   - Local model runner integration ✅
    - Extension marketplace and plugin API ✅
    - Persistent memory store ✅
 4. **v1.1+**
-   - Voice coding
+   - Voice coding ✅
    - Multi-agent code review
    - UI tests
 5. **v2.0 (16 wks)**

--- a/test/app/voice.test.js
+++ b/test/app/voice.test.js
@@ -1,0 +1,27 @@
+const { expect } = require('chai');
+const { createVoiceCoder } = require('../../app/voice');
+
+class MockRecognition {
+  constructor() { this.onresult = () => {}; }
+  start() { this.onstart && this.onstart(); this.onresult({ results: [[{ transcript: 'hello' }]] }); }
+  stop() { this.onstop && this.onstop(); }
+}
+
+describe('createVoiceCoder', () => {
+  it('inserts transcript on result', () => {
+    const edits = [];
+    const editor = {
+      getSelection: () => ({ startLineNumber:1, startColumn:1, endLineNumber:1, endColumn:1 }),
+      executeEdits: (_source, ops) => { edits.push(ops[0].text); }
+    };
+    const coder = createVoiceCoder(editor, MockRecognition);
+    coder.start();
+    expect(edits).to.deep.equal(['hello']);
+  });
+
+  it('throws if Recognition missing', () => {
+    let err;
+    try { createVoiceCoder({}); } catch (e) { err = e; }
+    expect(err).to.be.instanceOf(Error);
+  });
+});


### PR DESCRIPTION
## Summary
- add voice coding helper using Web Speech API
- wire voice input button into the Electron demo
- document the new feature
- mark roadmap items complete
- test voice coder

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68441de3205c8323972dfddf5f658e8e

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add voice coding functionality using the browser's SpeechRecognition API to enable speech-to-text input directly into the Monaco editor.

### Why are these changes being made?

Voice coding allows users to dictate code or text directly into the editor, enhancing accessibility and usability. The integration includes a "Voice" button in the UI to start and stop voice recognition sessions, and updates the ROADMAP to mark this task as complete for an improved development timeline tracking. The implementation is tested using a mock recognition class to ensure functionality, even in the absence of native support.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->