### PR TITLE
Implement ChatOps CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,22 @@ reviewers. Pass a diff to `review(diff)` and receive comments from each
 configured reviewer. The default reviewers include a senior developer and a
 security expert.
 
+## ChatOps CLI
+
+Automate common tasks using the `chatops` command line tool.
+
+Plan a goal:
+
+```bash
+node cli/chatops.js plan "add feature"
+```
+
+Synchronise the memory store with a remote URL:
+
+```bash
+node cli/chatops.js sync https://example.com/memory.json
+```
+
 ## Contributing
 
 Contributions are welcome! Fork the repository, create a new branch for your feature or bug fix, and submit a pull request. Please keep your commits concise and provide clear descriptions of your changes.

--- a/cli/chatops.js
+++ b/cli/chatops.js
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+const { plan } = require('../agent/task-planner');
+const { syncMemory } = require('../ai-service/cloud-sync');
+
+async function main(argv = process.argv.slice(2), { planFn = plan, syncFn = syncMemory } = {}) {
+  const [cmd, ...args] = argv;
+  if (cmd === 'plan') {
+    const goal = args.join(' ');
+    if (!goal) {
+      console.error('Usage: chatops plan <goal>');
+      return 1;
+    }
+    try {
+      const result = await planFn(goal);
+      console.log(result);
+      return 0;
+    } catch (err) {
+      console.error(err.message);
+      return 1;
+    }
+  }
+  if (cmd === 'sync') {
+    const url = args[0];
+    if (!url) {
+      console.error('Usage: chatops sync <url>');
+      return 1;
+    }
+    try {
+      await syncFn(url);
+      console.log('Sync complete');
+      return 0;
+    } catch (err) {
+      console.error(err.message);
+      return 1;
+    }
+  }
+  console.error('Usage: chatops <command> [args...]');
+  console.error('Commands: plan, sync');
+  return 1;
+}
+
+if (require.main === module) {
+  main().then((code) => { if (code !== 0) process.exit(code); });
+}
+
+module.exports = { main };

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -34,6 +34,6 @@ This document outlines the proposed plan for developing the AI IDE.
 5. **v2.0 (16 wks)**
    - Cloud sync across devices
    - Mobile companion app
-   - ChatOps CLI for automation
+   - ChatOps CLI for automation _(started)_
    - Code search indexing
    - GPU-accelerated local inference

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,9 @@
         "y-webrtc": "^10.3.0",
         "yjs": "^13.6.9"
       },
+      "bin": {
+        "chatops": "cli/chatops.js"
+      },
       "devDependencies": {
         "chai": "^4.3.7",
         "eslint": "^8.57.1",

--- a/package.json
+++ b/package.json
@@ -29,5 +29,8 @@
     "jsdom": "^26.1.0",
     "mocha": "^10.4.0",
     "prettier": "^3.5.3"
+  },
+  "bin": {
+    "chatops": "./cli/chatops.js"
   }
 }

--- a/test/cli/chatops.test.js
+++ b/test/cli/chatops.test.js
@@ -1,0 +1,37 @@
+const { expect } = require('chai');
+const { main } = require('../../cli/chatops');
+
+describe('chatops CLI', () => {
+  it('runs plan command', async () => {
+    let goalArg;
+    const code = await main(['plan', 'build', 'feature'], {
+      planFn: async (goal) => {
+        goalArg = goal;
+        return 'ok';
+      },
+      syncFn: async () => {},
+    });
+    expect(goalArg).to.equal('build feature');
+    expect(code).to.equal(0);
+  });
+
+  it('runs sync command', async () => {
+    let urlArg;
+    const code = await main(['sync', 'https://ex'], {
+      planFn: async () => 'x',
+      syncFn: async (url) => {
+        urlArg = url;
+      },
+    });
+    expect(urlArg).to.equal('https://ex');
+    expect(code).to.equal(0);
+  });
+
+  it('returns error on unknown command', async () => {
+    const code = await main(['unknown'], {
+      planFn: async () => {},
+      syncFn: async () => {},
+    });
+    expect(code).to.equal(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add a simple `chatops` CLI with plan and sync commands
- document the new CLI in README
- note roadmap progress for ChatOps CLI
- expose the CLI via `bin` field in `package.json`
- test coverage for the new CLI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684436ece3b48323b73e39f0491c8062