### PR TITLE
Start GPU inference roadmap item

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Alex 2.0 can also generate completions offline using [`llama.cpp`](https://githu
 ```bash
 export LLAMA_PATH=/path/to/main
 export LLAMA_MODEL=/path/to/model.gguf
+export LLAMA_GPU_LAYERS=35 # optional
 ```
 
 The `runLlama` helper in `ai-service/llama.js` executes the binary and returns the generated text.

--- a/ai-service/README.md
+++ b/ai-service/README.md
@@ -41,3 +41,10 @@ const { streamChatCompletion } = require('./openrouter');
 The wrapper validates that an `OPENROUTER_API_KEY` value is provided. If the `apiKey`
 option is empty, `streamChatCompletion` throws an error before making any
 requests.
+
+## Local Runner
+
+`llama.js` includes a `runLlama` helper that executes a local `llama.cpp` binary.
+Set `LLAMA_PATH` to the executable and `LLAMA_MODEL` to your GGUF weights. If
+`LLAMA_GPU_LAYERS` is defined, the helper passes `--n-gpu-layers` to offload that
+many layers to the GPU.

--- a/ai-service/llama.js
+++ b/ai-service/llama.js
@@ -32,9 +32,15 @@ async function runLlama(prompt, options = {}) {
   const exe = options.executable || process.env.LLAMA_PATH;
   const model = options.model || process.env.LLAMA_MODEL;
   const runner = options.runCmd || runCommand;
+  const gpuLayers =
+    options.gpuLayers || process.env.LLAMA_GPU_LAYERS || null;
   if (!exe) throw new Error('LLAMA_PATH is not set');
   if (!model) throw new Error('LLAMA_MODEL is not set');
-  return runner(exe, ['-m', model, '-p', prompt, '--silent-prompt']);
+  const args = ['-m', model, '-p', prompt, '--silent-prompt'];
+  if (gpuLayers) {
+    args.push('--n-gpu-layers', String(gpuLayers));
+  }
+  return runner(exe, args);
 }
 
 module.exports = { runLlama };

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -36,4 +36,4 @@ This document outlines the proposed plan for developing the AI IDE.
    - Mobile companion app
    - ChatOps CLI for automation _(started)_
    - Code search indexing _(started)_
-   - GPU-accelerated local inference
+   - GPU-accelerated local inference _(started)_

--- a/test/ai-service/llama.test.js
+++ b/test/ai-service/llama.test.js
@@ -1,9 +1,10 @@
 const { expect } = require('chai');
 const { runLlama } = require('../../ai-service/llama');
 
-function stubRunner(output, code = 0) {
-  return async () => {
+function stubRunner(output, code = 0, capture) {
+  return async (cmd, args) => {
     if (code !== 0) throw new Error(`llama exited with code ${code}`);
+    if (capture) capture(args);
     return output;
   };
 }
@@ -27,5 +28,20 @@ describe('runLlama', () => {
     }
     expect(err).to.be.instanceOf(Error);
     expect(err.message).to.equal('LLAMA_PATH is not set');
+  });
+
+  it('passes gpu layers option', async () => {
+    process.env.LLAMA_PATH = '/bin/llama';
+    process.env.LLAMA_MODEL = 'model.gguf';
+    process.env.LLAMA_GPU_LAYERS = '2';
+    let args;
+    await runLlama('Hi', {
+      runCmd: stubRunner('ok', 0, (a) => {
+        args = a;
+      }),
+    });
+    expect(args).to.include('--n-gpu-layers');
+    const idx = args.indexOf('--n-gpu-layers');
+    expect(args[idx + 1]).to.equal('2');
   });
 });


### PR DESCRIPTION
## Summary
- enable GPU layer support in local llama runner
- document LLAMA_GPU_LAYERS in README and ai-service docs
- mark GPU accelerated inference as started on the roadmap
- test GPU flag passing for runLlama

## Testing
- `npm test` *(fails: `npm: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68443cac0f248323b1f219c20bf991dc

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add support for GPU acceleration in local inference by introducing an optional `LLAMA_GPU_LAYERS` configuration for the `runLlama` helper to specify the number of layers to offload to the GPU.

### Why are these changes being made?

These changes are part of the roadmap item to implement GPU-accelerated local inference, enhancing the performance of model inference by offloading computations to the GPU. This update allows users to leverage available GPU resources, optimizing processing speed for tasks run through the `llama.js` service. The changes also ensure backwards compatibility by making GPU configuration optional.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->