### PR TITLE
Start cloud sync watcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,21 @@ Synchronise the memory store with a remote URL:
 node cli/chatops.js sync https://example.com/memory.json
 ```
 
+## Cloud Sync Watcher
+
+Automatically keep your memory file in sync across devices. Use
+`startSyncWatcher(url, opts)` from `ai-service/sync-watcher.js` to periodically
+merge and upload changes:
+
+```javascript
+const { startSyncWatcher } = require('./ai-service/sync-watcher');
+
+const watcher = startSyncWatcher('https://example.com/memory.json', {
+  interval: 30000,
+});
+// Call watcher.stop() to disable syncing
+```
+
 ## Contributing
 
 Contributions are welcome! Fork the repository, create a new branch for your feature or bug fix, and submit a pull request. Please keep your commits concise and provide clear descriptions of your changes.

--- a/ai-service/sync-watcher.js
+++ b/ai-service/sync-watcher.js
@@ -1,0 +1,26 @@
+const { syncMemory } = require('./cloud-sync');
+
+function startSyncWatcher(url, {
+  interval = 60000,
+  file = 'memory.json',
+  fetchFn = fetch,
+  syncFn = syncMemory,
+  setTimer = setInterval,
+  clearTimer = clearInterval,
+} = {}) {
+  async function run() {
+    try {
+      await syncFn(url, file, fetchFn);
+    } catch (err) {
+      console.error('sync error:', err.message);
+    }
+  }
+  const id = setTimer(run, interval);
+  return {
+    stop() {
+      clearTimer(id);
+    },
+  };
+}
+
+module.exports = { startSyncWatcher };

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -32,7 +32,7 @@ This document outlines the proposed plan for developing the AI IDE.
    - Multi-agent code review ✅
    - UI tests ✅
 5. **v2.0 (16 wks)**
-   - Cloud sync across devices
+   - Cloud sync across devices _(started)_
    - Mobile companion app
    - ChatOps CLI for automation _(started)_
    - Code search indexing _(started)_

--- a/test/ai-service/sync-watcher.test.js
+++ b/test/ai-service/sync-watcher.test.js
@@ -1,0 +1,43 @@
+const { expect } = require('chai');
+const { startSyncWatcher } = require('../../ai-service/sync-watcher');
+
+describe('sync watcher', () => {
+  it('invokes sync on interval', async () => {
+    let fn;
+    const timerIds = [];
+    function setTimer(cb) {
+      fn = cb;
+      const id = timerIds.length + 1;
+      timerIds.push(id);
+      return id;
+    }
+    let clearedId;
+    function clearTimer(id) {
+      clearedId = id;
+    }
+    let calls = 0;
+    const watcher = startSyncWatcher('u', {
+      interval: 10,
+      syncFn: async () => { calls++; },
+      setTimer,
+      clearTimer,
+      fetchFn: async () => new Response('[]', { status: 200 })
+    });
+    await fn();
+    expect(calls).to.equal(1);
+    watcher.stop();
+    expect(clearedId).to.equal(timerIds[0]);
+  });
+
+  it('swallows errors from sync', async () => {
+    let fn;
+    const watcher = startSyncWatcher('u', {
+      interval: 5,
+      syncFn: async () => { throw new Error('fail'); },
+      setTimer: (cb) => { fn = cb; return 1; },
+      clearTimer: () => {},
+    });
+    await fn();
+    watcher.stop();
+  });
+});


### PR DESCRIPTION
## Summary
- add a sync watcher to keep memory files synced
- document the watcher in the README
- mark cloud sync started on the roadmap
- test the watcher

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68443f5d9c6c8323b53ef4f0468fc8b9