### PR TITLE
Add minimal mobile web client

### DIFF
--- a/mobile/README.md
+++ b/mobile/README.md
@@ -6,6 +6,9 @@ It exposes two routes:
 - `GET /memory` – returns the stored conversation history.
 - `POST /chat` – sends a chat message and returns the assistant response.
 
+The server also serves a small web interface from `/` that you can open in a
+mobile browser to view the history and send messages.
+
 Run the server:
 
 ```bash

--- a/mobile/public/index.html
+++ b/mobile/public/index.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Alex Mobile</title>
+  <style>
+    body { font-family: sans-serif; padding: 1em; }
+    #history { border: 1px solid #ccc; padding: 0.5em; height: 200px; overflow-y: auto; white-space: pre-wrap; }
+    #input { width: 80%; }
+  </style>
+</head>
+<body>
+  <div id="history"></div>
+  <input id="input" placeholder="Type a message..." />
+  <button id="send">Send</button>
+  <script>
+    async function loadHistory() {
+      const res = await fetch('/memory');
+      const data = await res.json();
+      const hist = document.getElementById('history');
+      hist.textContent = data.map(e => `${e.role}: ${e.content}`).join('\n');
+    }
+    async function send() {
+      const input = document.getElementById('input');
+      const message = input.value.trim();
+      if (!message) return;
+      input.value = '';
+      const res = await fetch('/chat', { method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({ message }) });
+      const data = await res.json();
+      await loadHistory();
+      const hist = document.getElementById('history');
+      hist.textContent += `\nassistant: ${data.response}`;
+    }
+    document.getElementById('send').addEventListener('click', send);
+    loadHistory();
+  </script>
+</body>
+</html>

--- a/mobile/server.js
+++ b/mobile/server.js
@@ -2,12 +2,16 @@ const express = require('express');
 const { load, append } = require('../ai-service/memory-store');
 const { runChat } = require('../app/chat');
 
+const { join } = require('path');
+
 function createServer({
   runChat: chatImpl = runChat,
   memoryFile = 'memory.json',
+  staticDir = join(__dirname, 'public'),
 } = {}) {
   const app = express();
   app.use(express.json());
+  app.use(express.static(staticDir));
 
   app.get('/memory', (req, res) => {
     res.json(load(memoryFile));

--- a/test/mobile/server.test.js
+++ b/test/mobile/server.test.js
@@ -42,4 +42,11 @@ describe('mobile server', () => {
     const res = await request(app).post('/chat').send({});
     expect(res.status).to.equal(400);
   });
+
+  it('serves static index', async () => {
+    const app = createServer({ memoryFile: file, runChat: async () => {} });
+    const res = await request(app).get('/');
+    expect(res.status).to.equal(200);
+    expect(res.text).to.include('<!doctype html>');
+  });
 });


### PR DESCRIPTION
## Summary
- serve static files from the mobile server
- add a tiny browser UI for viewing memory and chatting
- document the new mobile interface
- test that the server returns the index page

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684440e9c2308323a3eaecfb03372ccf


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.
