### PR TITLE
Add watch command for ChatOps CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,12 @@ Synchronise the memory store with a remote URL:
 node cli/chatops.js sync https://example.com/memory.json
 ```
 
+Start a background watcher to periodically sync:
+
+```bash
+node cli/chatops.js watch https://example.com/memory.json
+```
+
 ## Cloud Sync Watcher
 
 Automatically keep your memory file in sync across devices. Use

--- a/cli/chatops.js
+++ b/cli/chatops.js
@@ -1,8 +1,13 @@
 #!/usr/bin/env node
 const { plan } = require('../agent/task-planner');
 const { syncMemory } = require('../ai-service/cloud-sync');
+const { startSyncWatcher } = require('../ai-service/sync-watcher');
 
-async function main(argv = process.argv.slice(2), { planFn = plan, syncFn = syncMemory } = {}) {
+async function main(argv = process.argv.slice(2), {
+  planFn = plan,
+  syncFn = syncMemory,
+  watchFn = startSyncWatcher,
+} = {}) {
   const [cmd, ...args] = argv;
   if (cmd === 'plan') {
     const goal = args.join(' ');
@@ -34,8 +39,23 @@ async function main(argv = process.argv.slice(2), { planFn = plan, syncFn = sync
       return 1;
     }
   }
+  if (cmd === 'watch') {
+    const url = args[0];
+    if (!url) {
+      console.error('Usage: chatops watch <url>');
+      return 1;
+    }
+    try {
+      watchFn(url);
+      console.log('Watcher started');
+      return 0;
+    } catch (err) {
+      console.error(err.message);
+      return 1;
+    }
+  }
   console.error('Usage: chatops <command> [args...]');
-  console.error('Commands: plan, sync');
+  console.error('Commands: plan, sync, watch');
   return 1;
 }
 

--- a/test/cli/chatops.test.js
+++ b/test/cli/chatops.test.js
@@ -22,8 +22,26 @@ describe('chatops CLI', () => {
       syncFn: async (url) => {
         urlArg = url;
       },
+      watchFn: async () => {},
     });
     expect(urlArg).to.equal('https://ex');
+    expect(code).to.equal(0);
+  });
+
+  it('starts watch command', async () => {
+    let urlArg;
+    let called = false;
+    const code = await main(['watch', 'https://ex'], {
+      planFn: async () => {},
+      syncFn: async () => {},
+      watchFn: (url) => {
+        urlArg = url;
+        called = true;
+        return { stop() {} };
+      },
+    });
+    expect(urlArg).to.equal('https://ex');
+    expect(called).to.be.true;
     expect(code).to.equal(0);
   });
 
@@ -31,6 +49,7 @@ describe('chatops CLI', () => {
     const code = await main(['unknown'], {
       planFn: async () => {},
       syncFn: async () => {},
+      watchFn: async () => {},
     });
     expect(code).to.equal(1);
   });


### PR DESCRIPTION
## Summary
- extend `chatops.js` with `watch` command
- document the new command in README
- test watch command in chatops CLI tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68444ab1be748323b20868476447fe4a


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.
