### PR TITLE
Implement cloud memory server for sync

### DIFF
--- a/cloud/README.md
+++ b/cloud/README.md
@@ -1,0 +1,14 @@
+# Cloud Memory Server
+
+This simple Express server stores conversation memory for cloud sync.
+
+It exposes a single `/memory` endpoint:
+
+- `GET /memory` returns the stored JSON array
+- `PUT /memory` replaces the stored data with the provided JSON array
+
+Start the server:
+
+```bash
+node cloud/index.js
+```

--- a/cloud/index.js
+++ b/cloud/index.js
@@ -1,0 +1,5 @@
+const { createServer } = require('./server');
+const port = process.env.PORT || 8080;
+createServer().listen(port, () => {
+  console.log(`Cloud sync server listening on ${port}`);
+});

--- a/cloud/server.js
+++ b/cloud/server.js
@@ -1,0 +1,28 @@
+const express = require('express');
+const fs = require('fs');
+
+function createServer({ memoryFile = 'memory.json' } = {}) {
+  const app = express();
+  app.use(express.json());
+
+  app.get('/memory', (req, res) => {
+    let data = '[]';
+    if (fs.existsSync(memoryFile)) {
+      data = fs.readFileSync(memoryFile, 'utf8');
+    }
+    res.type('json').send(data);
+  });
+
+  app.put('/memory', (req, res) => {
+    if (!Array.isArray(req.body)) {
+      res.status(400).json({ error: 'invalid data' });
+      return;
+    }
+    fs.writeFileSync(memoryFile, JSON.stringify(req.body, null, 2));
+    res.json({ ok: true });
+  });
+
+  return app;
+}
+
+module.exports = { createServer };

--- a/test/cloud/server.test.js
+++ b/test/cloud/server.test.js
@@ -1,0 +1,38 @@
+const { expect } = require('chai');
+const fs = require('fs');
+const os = require('os');
+const { join } = require('path');
+const request = require('supertest');
+const { createServer } = require('../../cloud/server');
+
+describe('cloud memory server', () => {
+  let file;
+  beforeEach(() => {
+    file = join(fs.mkdtempSync(join(os.tmpdir(), 'cloud-')), 'mem.json');
+    fs.writeFileSync(file, '[]');
+  });
+
+  it('returns stored memory', async () => {
+    fs.writeFileSync(file, '[{"msg":"a"}]');
+    const app = createServer({ memoryFile: file });
+    const res = await request(app).get('/memory');
+    expect(res.status).to.equal(200);
+    expect(res.text).to.equal('[{"msg":"a"}]');
+  });
+
+  it('replaces memory via PUT', async () => {
+    const app = createServer({ memoryFile: file });
+    const res = await request(app)
+      .put('/memory')
+      .send([{ msg: 'b' }]);
+    expect(res.status).to.equal(200);
+    const data = fs.readFileSync(file, 'utf8');
+    expect(JSON.parse(data)).to.deep.equal([{ msg: 'b' }]);
+  });
+
+  it('validates PUT body', async () => {
+    const app = createServer({ memoryFile: file });
+    const res = await request(app).put('/memory').send({});
+    expect(res.status).to.equal(400);
+  });
+});


### PR DESCRIPTION
## Summary
- add simple express server for remote memory storage
- provide CLI entrypoint to run the server
- document how to start the server
- test cloud memory server endpoints

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684450a24d288323aa3a24210a3c4218


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.
