### PR TITLE
Add chat memory sync support

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,10 @@ const watcher = startSyncWatcher('https://example.com/memory.json', {
 // Call watcher.stop() to disable syncing
 ```
 
+Set `MEMORY_FILE` to the path of a local JSON file and `MEMORY_SYNC_URL` to a
+remote `/memory` endpoint to have the desktop app automatically store and sync
+chat history after each message.
+
 ## Contributing
 
 Contributions are welcome! Fork the repository, create a new branch for your feature or bug fix, and submit a pull request. Please keep your commits concise and provide clear descriptions of your changes.

--- a/app/chat-memory.js
+++ b/app/chat-memory.js
@@ -1,0 +1,52 @@
+const { runChat } = require('./chat');
+const { append } = require('../ai-service/memory-store');
+const { syncMemory } = require('../ai-service/cloud-sync');
+
+/**
+ * Run chat and persist the conversation to disk.
+ *
+ * @param {Array<{role:string,content:string}>} messages Chat messages
+ * @param {(token:string)=>void} onToken Callback for streamed tokens
+ * @param {object} [options]
+ * @param {string} [options.memoryFile=process.env.MEMORY_FILE] Path to memory JSON file
+ * @param {string} [options.syncUrl=process.env.MEMORY_SYNC_URL] Remote URL for cloud sync
+ * @param {Function} [options.runChat] Chat implementation
+ * @param {Function} [options.appendFn] Append function for testing
+ * @param {Function} [options.syncFn] Sync function for testing
+ * @returns {Promise<void>}
+ */
+async function runChatWithMemory(
+  messages,
+  onToken,
+  {
+    memoryFile = process.env.MEMORY_FILE,
+    syncUrl = process.env.MEMORY_SYNC_URL,
+    runChat: chatImpl = runChat,
+    appendFn = append,
+    syncFn = syncMemory,
+    ...chatOpts
+  } = {}
+) {
+  let response = '';
+  await chatImpl(
+    messages,
+    (tok) => {
+      response += tok;
+      if (onToken) onToken(tok);
+    },
+    chatOpts
+  );
+  if (memoryFile) {
+    for (const m of messages) appendFn(m, memoryFile);
+    appendFn({ role: 'assistant', content: response }, memoryFile);
+    if (syncUrl) {
+      try {
+        await syncFn(syncUrl, memoryFile);
+      } catch (err) {
+        console.error('sync error:', err.message);
+      }
+    }
+  }
+}
+
+module.exports = { runChatWithMemory };

--- a/app/ui.js
+++ b/app/ui.js
@@ -1,11 +1,12 @@
 const { runChat } = require('./chat');
+const { runChatWithMemory } = require('./chat-memory');
 const { createVoiceCoder } = require('./voice');
 
 function setupUI(
   doc,
   editor,
   {
-    runChat: chatImpl = runChat,
+    runChat: chatImpl = runChatWithMemory,
     createVoiceCoder: voiceCtor = createVoiceCoder,
   } = {}
 ) {

--- a/test/app/chat-memory.test.js
+++ b/test/app/chat-memory.test.js
@@ -1,0 +1,34 @@
+const { expect } = require('chai');
+const fs = require('fs');
+const os = require('os');
+const { join } = require('path');
+const { runChatWithMemory } = require('../../app/chat-memory');
+
+function mockChat(output) {
+  return async (_msgs, onToken) => {
+    onToken(output);
+  };
+}
+
+describe('runChatWithMemory', () => {
+  it('stores messages and syncs when configured', async () => {
+    const dir = fs.mkdtempSync(join(os.tmpdir(), 'mem-'));
+    const file = join(dir, 'memory.json');
+    fs.writeFileSync(file, '[]');
+    let syncArg;
+    await runChatWithMemory([
+      { role: 'user', content: 'hi' }
+    ], () => {}, {
+      memoryFile: file,
+      syncUrl: 'https://remote',
+      runChat: mockChat('ok'),
+      syncFn: async (url, f) => { syncArg = `${url}|${f}`; },
+    });
+    const data = JSON.parse(fs.readFileSync(file, 'utf8'));
+    expect(data).to.deep.equal([
+      { role: 'user', content: 'hi' },
+      { role: 'assistant', content: 'ok' },
+    ]);
+    expect(syncArg).to.equal(`https://remote|${file}`);
+  });
+});


### PR DESCRIPTION
## Summary
- add `runChatWithMemory` helper to store conversations and sync them
- integrate memory sync with default UI chat handler
- document `MEMORY_FILE` and `MEMORY_SYNC_URL` usage
- test new memory sync behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68445c6d3b28832381ab01d465aa62bd