### PR TITLE
Implement code search command

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,12 @@ Start a background watcher to periodically sync:
 node cli/chatops.js watch https://example.com/memory.json
 ```
 
+Search code for a word:
+
+```bash
+node cli/chatops.js search TODO src
+```
+
 ## Cloud Sync Watcher
 
 Automatically keep your memory file in sync across devices. Use

--- a/cli/chatops.js
+++ b/cli/chatops.js
@@ -2,12 +2,18 @@
 const { plan } = require('../agent/task-planner');
 const { syncMemory } = require('../ai-service/cloud-sync');
 const { startSyncWatcher } = require('../ai-service/sync-watcher');
+const { createIndex, search: searchIdx } = require('../search/indexer');
 
-async function main(argv = process.argv.slice(2), {
-  planFn = plan,
-  syncFn = syncMemory,
-  watchFn = startSyncWatcher,
-} = {}) {
+async function main(
+  argv = process.argv.slice(2),
+  {
+    planFn = plan,
+    syncFn = syncMemory,
+    watchFn = startSyncWatcher,
+    indexFn = createIndex,
+    searchFn = searchIdx,
+  } = {}
+) {
   const [cmd, ...args] = argv;
   if (cmd === 'plan') {
     const goal = args.join(' ');
@@ -54,8 +60,27 @@ async function main(argv = process.argv.slice(2), {
       return 1;
     }
   }
+  if (cmd === 'search') {
+    const term = args[0];
+    const dir = args[1] || '.';
+    if (!term) {
+      console.error('Usage: chatops search <term> [dir]');
+      return 1;
+    }
+    try {
+      const idx = indexFn(dir);
+      const results = searchFn(idx, term);
+      for (const r of results) {
+        console.log(`${r.file}:${r.line}: ${r.text}`);
+      }
+      return 0;
+    } catch (err) {
+      console.error(err.message);
+      return 1;
+    }
+  }
   console.error('Usage: chatops <command> [args...]');
-  console.error('Commands: plan, sync, watch');
+  console.error('Commands: plan, sync, watch, search');
   return 1;
 }
 

--- a/test/cli/chatops.test.js
+++ b/test/cli/chatops.test.js
@@ -45,6 +45,27 @@ describe('chatops CLI', () => {
     expect(code).to.equal(0);
   });
 
+  it('runs search command', async () => {
+    let dirArg;
+    let termArg;
+    const code = await main(['search', 'foo', '/tmp'], {
+      planFn: async () => {},
+      syncFn: async () => {},
+      watchFn: async () => {},
+      indexFn: (dir) => {
+        dirArg = dir;
+        return { dir };
+      },
+      searchFn: (idx, term) => {
+        termArg = term;
+        return [{ file: 'a.js', line: 1, text: 'foo' }];
+      },
+    });
+    expect(dirArg).to.equal('/tmp');
+    expect(termArg).to.equal('foo');
+    expect(code).to.equal(0);
+  });
+
   it('returns error on unknown command', async () => {
     const code = await main(['unknown'], {
       planFn: async () => {},


### PR DESCRIPTION
## Summary
- extend `chatops` CLI with `search` command
- test new `search` option
- document `search` usage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68445ec5dd68832381fc8b0eff503c51