### PR TITLE
Add file argument for chatops sync/watch

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,13 +134,13 @@ node cli/chatops.js plan "add feature"
 Synchronise the memory store with a remote URL:
 
 ```bash
-node cli/chatops.js sync https://example.com/memory.json
+node cli/chatops.js sync https://example.com/memory.json path/to/memory.json
 ```
 
 Start a background watcher to periodically sync:
 
 ```bash
-node cli/chatops.js watch https://example.com/memory.json
+node cli/chatops.js watch https://example.com/memory.json path/to/memory.json
 ```
 
 Search code for a word:
@@ -160,6 +160,7 @@ const { startSyncWatcher } = require('./ai-service/sync-watcher');
 
 const watcher = startSyncWatcher('https://example.com/memory.json', {
   interval: 30000,
+  file: 'path/to/memory.json',
 });
 // Call watcher.stop() to disable syncing
 ```

--- a/cli/chatops.js
+++ b/cli/chatops.js
@@ -32,12 +32,13 @@ async function main(
   }
   if (cmd === 'sync') {
     const url = args[0];
+    const file = args[1];
     if (!url) {
-      console.error('Usage: chatops sync <url>');
+      console.error('Usage: chatops sync <url> [file]');
       return 1;
     }
     try {
-      await syncFn(url);
+      await syncFn(url, file);
       console.log('Sync complete');
       return 0;
     } catch (err) {
@@ -47,12 +48,13 @@ async function main(
   }
   if (cmd === 'watch') {
     const url = args[0];
+    const file = args[1];
     if (!url) {
-      console.error('Usage: chatops watch <url>');
+      console.error('Usage: chatops watch <url> [file]');
       return 1;
     }
     try {
-      watchFn(url);
+      watchFn(url, { file });
       console.log('Watcher started');
       return 0;
     } catch (err) {

--- a/test/cli/chatops.test.js
+++ b/test/cli/chatops.test.js
@@ -16,31 +16,31 @@ describe('chatops CLI', () => {
   });
 
   it('runs sync command', async () => {
-    let urlArg;
-    const code = await main(['sync', 'https://ex'], {
+    let args;
+    const code = await main(['sync', 'https://ex', '/tmp/mem.json'], {
       planFn: async () => 'x',
-      syncFn: async (url) => {
-        urlArg = url;
+      syncFn: async (url, file) => {
+        args = `${url}|${file}`;
       },
       watchFn: async () => {},
     });
-    expect(urlArg).to.equal('https://ex');
+    expect(args).to.equal('https://ex|/tmp/mem.json');
     expect(code).to.equal(0);
   });
 
   it('starts watch command', async () => {
-    let urlArg;
+    let args;
     let called = false;
-    const code = await main(['watch', 'https://ex'], {
+    const code = await main(['watch', 'https://ex', '/tmp/mem.json'], {
       planFn: async () => {},
       syncFn: async () => {},
-      watchFn: (url) => {
-        urlArg = url;
+      watchFn: (url, opts) => {
+        args = `${url}|${opts.file}`;
         called = true;
         return { stop() {} };
       },
     });
-    expect(urlArg).to.equal('https://ex');
+    expect(args).to.equal('https://ex|/tmp/mem.json');
     expect(called).to.be.true;
     expect(code).to.equal(0);
   });


### PR DESCRIPTION
## Summary
- allow specifying a memory file when running `chatops sync` or `chatops watch`
- document the new argument and update sync watcher example
- test passing the file path through the CLI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68446252b7408323907cba3926628d4c

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a file argument to the `chatops sync` and `chatops watch` commands to specify a file path for local storage.

### Why are these changes being made?

The changes allow users to specify a local file path for storing the synced data, enhancing flexibility and usability for scenarios where local storage of the memory store's data is required. This feature was requested to increase the utility of the `sync` and `watch` functionalities.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->