### PR TITLE
Add upload/download commands to chatops

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,18 @@ Synchronise the memory store with a remote URL:
 node cli/chatops.js sync https://example.com/memory.json path/to/memory.json
 ```
 
+Upload the local memory file without merging:
+
+```bash
+node cli/chatops.js upload https://example.com/memory.json path/to/memory.json
+```
+
+Download the remote memory file:
+
+```bash
+node cli/chatops.js download https://example.com/memory.json path/to/memory.json
+```
+
 Start a background watcher to periodically sync:
 
 ```bash

--- a/app/ui.js
+++ b/app/ui.js
@@ -1,4 +1,3 @@
-const { runChat } = require('./chat');
 const { runChatWithMemory } = require('./chat-memory');
 const { createVoiceCoder } = require('./voice');
 

--- a/cli/chatops.js
+++ b/cli/chatops.js
@@ -1,6 +1,10 @@
 #!/usr/bin/env node
 const { plan } = require('../agent/task-planner');
-const { syncMemory } = require('../ai-service/cloud-sync');
+const {
+  uploadMemory,
+  downloadMemory,
+  syncMemory,
+} = require('../ai-service/cloud-sync');
 const { startSyncWatcher } = require('../ai-service/sync-watcher');
 const { createIndex, search: searchIdx } = require('../search/indexer');
 
@@ -9,6 +13,8 @@ async function main(
   {
     planFn = plan,
     syncFn = syncMemory,
+    uploadFn = uploadMemory,
+    downloadFn = downloadMemory,
     watchFn = startSyncWatcher,
     indexFn = createIndex,
     searchFn = searchIdx,
@@ -40,6 +46,38 @@ async function main(
     try {
       await syncFn(url, file);
       console.log('Sync complete');
+      return 0;
+    } catch (err) {
+      console.error(err.message);
+      return 1;
+    }
+  }
+  if (cmd === 'upload') {
+    const url = args[0];
+    const file = args[1];
+    if (!url) {
+      console.error('Usage: chatops upload <url> [file]');
+      return 1;
+    }
+    try {
+      await uploadFn(url, file);
+      console.log('Upload complete');
+      return 0;
+    } catch (err) {
+      console.error(err.message);
+      return 1;
+    }
+  }
+  if (cmd === 'download') {
+    const url = args[0];
+    const file = args[1];
+    if (!url) {
+      console.error('Usage: chatops download <url> [file]');
+      return 1;
+    }
+    try {
+      await downloadFn(url, file);
+      console.log('Download complete');
       return 0;
     } catch (err) {
       console.error(err.message);
@@ -82,12 +120,14 @@ async function main(
     }
   }
   console.error('Usage: chatops <command> [args...]');
-  console.error('Commands: plan, sync, watch, search');
+  console.error('Commands: plan, sync, upload, download, watch, search');
   return 1;
 }
 
 if (require.main === module) {
-  main().then((code) => { if (code !== 0) process.exit(code); });
+  main().then((code) => {
+    if (code !== 0) process.exit(code);
+  });
 }
 
 module.exports = { main };

--- a/test/cli/chatops.test.js
+++ b/test/cli/chatops.test.js
@@ -22,6 +22,38 @@ describe('chatops CLI', () => {
       syncFn: async (url, file) => {
         args = `${url}|${file}`;
       },
+      uploadFn: async () => {},
+      downloadFn: async () => {},
+      watchFn: async () => {},
+    });
+    expect(args).to.equal('https://ex|/tmp/mem.json');
+    expect(code).to.equal(0);
+  });
+
+  it('runs upload command', async () => {
+    let args;
+    const code = await main(['upload', 'https://ex', '/tmp/mem.json'], {
+      planFn: async () => {},
+      syncFn: async () => {},
+      uploadFn: async (url, file) => {
+        args = `${url}|${file}`;
+      },
+      downloadFn: async () => {},
+      watchFn: async () => {},
+    });
+    expect(args).to.equal('https://ex|/tmp/mem.json');
+    expect(code).to.equal(0);
+  });
+
+  it('runs download command', async () => {
+    let args;
+    const code = await main(['download', 'https://ex', '/tmp/mem.json'], {
+      planFn: async () => {},
+      syncFn: async () => {},
+      uploadFn: async () => {},
+      downloadFn: async (url, file) => {
+        args = `${url}|${file}`;
+      },
       watchFn: async () => {},
     });
     expect(args).to.equal('https://ex|/tmp/mem.json');
@@ -34,6 +66,8 @@ describe('chatops CLI', () => {
     const code = await main(['watch', 'https://ex', '/tmp/mem.json'], {
       planFn: async () => {},
       syncFn: async () => {},
+      uploadFn: async () => {},
+      downloadFn: async () => {},
       watchFn: (url, opts) => {
         args = `${url}|${opts.file}`;
         called = true;
@@ -51,6 +85,8 @@ describe('chatops CLI', () => {
     const code = await main(['search', 'foo', '/tmp'], {
       planFn: async () => {},
       syncFn: async () => {},
+      uploadFn: async () => {},
+      downloadFn: async () => {},
       watchFn: async () => {},
       indexFn: (dir) => {
         dirArg = dir;
@@ -70,6 +106,8 @@ describe('chatops CLI', () => {
     const code = await main(['unknown'], {
       planFn: async () => {},
       syncFn: async () => {},
+      uploadFn: async () => {},
+      downloadFn: async () => {},
       watchFn: async () => {},
     });
     expect(code).to.equal(1);


### PR DESCRIPTION
## Summary
- extend `chatops` CLI with `upload` and `download` subcommands
- document new commands in README
- remove unused import from `app/ui.js`
- test new CLI behaviour

## Testing
- `npm test`
- `npm run lint`
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_6844651f3c248323b988e4edafa74b8f