### PR TITLE
Implement memory sync watcher integration

### DIFF
--- a/app/ui.js
+++ b/app/ui.js
@@ -1,5 +1,6 @@
 const { runChatWithMemory } = require('./chat-memory');
 const { createVoiceCoder } = require('./voice');
+const { startSyncWatcher } = require('../ai-service/sync-watcher');
 
 function setupUI(
   doc,
@@ -7,8 +8,18 @@ function setupUI(
   {
     runChat: chatImpl = runChatWithMemory,
     createVoiceCoder: voiceCtor = createVoiceCoder,
+    startSyncWatcher: watcherCtor = startSyncWatcher,
   } = {}
 ) {
+  let watcher;
+  if (process.env.MEMORY_SYNC_URL && watcherCtor) {
+    watcher = watcherCtor(process.env.MEMORY_SYNC_URL, {
+      file: process.env.MEMORY_FILE,
+    });
+    if (doc.defaultView) {
+      doc.defaultView.addEventListener('beforeunload', () => watcher.stop());
+    }
+  }
   let voice;
   doc.getElementById('voice-btn').onclick = () => {
     if (!voice) {

--- a/test/app/ui.test.js
+++ b/test/app/ui.test.js
@@ -58,4 +58,29 @@ describe('UI integration', () => {
     expect(stopped).to.be.true;
     expect(btn.textContent).to.equal('Voice');
   });
+
+  it('starts sync watcher when MEMORY_SYNC_URL set', () => {
+    const doc = createDom();
+    process.env.MEMORY_SYNC_URL = 'https://remote';
+    process.env.MEMORY_FILE = 'm.json';
+    let args;
+    let stopped = false;
+    setupUI(
+      doc,
+      {},
+      {
+        runChat: async () => {},
+        createVoiceCoder: () => ({ start() {}, stop() {} }),
+        startSyncWatcher: (url, opts) => {
+          args = `${url}|${opts.file}`;
+          return { stop: () => { stopped = true; } };
+        },
+      }
+    );
+    expect(args).to.equal('https://remote|m.json');
+    doc.defaultView.dispatchEvent(new doc.defaultView.Event('beforeunload'));
+    expect(stopped).to.be.true;
+    delete process.env.MEMORY_SYNC_URL;
+    delete process.env.MEMORY_FILE;
+  });
 });


### PR DESCRIPTION
## Summary
- start the cloud sync watcher in the app UI when `MEMORY_SYNC_URL` is set
- stop the watcher on window unload
- test that the watcher starts and stops properly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68446746bd888323b4ba1713b3d6e307