### PR TITLE
Implement memory delete endpoint

### DIFF
--- a/cloud/README.md
+++ b/cloud/README.md
@@ -6,6 +6,7 @@ It exposes a single `/memory` endpoint:
 
 - `GET /memory` returns the stored JSON array
 - `PUT /memory` replaces the stored data with the provided JSON array
+- `DELETE /memory` clears the stored data
 
 Start the server:
 

--- a/cloud/server.js
+++ b/cloud/server.js
@@ -22,6 +22,11 @@ function createServer({ memoryFile = 'memory.json' } = {}) {
     res.json({ ok: true });
   });
 
+  app.delete('/memory', (req, res) => {
+    fs.writeFileSync(memoryFile, '[]');
+    res.json({ ok: true });
+  });
+
   return app;
 }
 

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -1,10 +1,11 @@
 # Mobile Companion Server
 
 This directory contains a minimal HTTP API intended for the mobile companion app.
-It exposes two routes:
+It exposes three routes:
 
 - `GET /memory` – returns the stored conversation history.
 - `POST /chat` – sends a chat message and returns the assistant response.
+- `DELETE /memory` – clears the stored conversation history.
 
 The server also serves a small web interface from `/` that you can open in a
 mobile browser to view the history and send messages.

--- a/mobile/server.js
+++ b/mobile/server.js
@@ -1,4 +1,5 @@
 const express = require('express');
+const fs = require('fs');
 const { load, append } = require('../ai-service/memory-store');
 const { runChat } = require('../app/chat');
 const { syncMemory } = require('../ai-service/cloud-sync');
@@ -40,6 +41,22 @@ function createServer({
         }
       }
       res.json({ response: responseText });
+    } catch (err) {
+      res.status(500).json({ error: err.message });
+    }
+  });
+
+  app.delete('/memory', async (req, res) => {
+    try {
+      fs.writeFileSync(memoryFile, '[]');
+      if (syncUrl) {
+        try {
+          await syncFn(syncUrl, memoryFile);
+        } catch (err) {
+          console.error('sync error:', err.message);
+        }
+      }
+      res.json({ ok: true });
     } catch (err) {
       res.status(500).json({ error: err.message });
     }

--- a/test/cloud/server.test.js
+++ b/test/cloud/server.test.js
@@ -35,4 +35,13 @@ describe('cloud memory server', () => {
     const res = await request(app).put('/memory').send({});
     expect(res.status).to.equal(400);
   });
+
+  it('clears memory via DELETE', async () => {
+    fs.writeFileSync(file, '[{"a":1}]');
+    const app = createServer({ memoryFile: file });
+    const res = await request(app).delete('/memory');
+    expect(res.status).to.equal(200);
+    const data = fs.readFileSync(file, 'utf8');
+    expect(data).to.equal('[]');
+  });
 });

--- a/test/mobile/server.test.js
+++ b/test/mobile/server.test.js
@@ -63,4 +63,13 @@ describe('mobile server', () => {
     expect(res.status).to.equal(200);
     expect(res.text).to.include('<!doctype html>');
   });
+
+  it('clears memory via DELETE', async () => {
+    fs.writeFileSync(file, '[1]');
+    const app = createServer({ memoryFile: file, runChat: async () => {} });
+    const res = await request(app).delete('/memory');
+    expect(res.status).to.equal(200);
+    const data = fs.readFileSync(file, 'utf8');
+    expect(data).to.equal('[]');
+  });
 });


### PR DESCRIPTION
## Summary
- clear memory with DELETE /memory on cloud server
- support DELETE /memory on mobile server and document routes
- test deleting memory on both servers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684468c34d3483239187cdddf656ca13

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Implement a `DELETE /memory` endpoint to clear stored data for both the cloud and mobile servers.

### Why are these changes being made?

The addition of a `DELETE /memory` endpoint provides an ability to reset or clear stored data, which aligns with the management needs for both servers. This change enhances the API by providing a cleaner way to manage data state, with the implementation verified through corresponding test cases to ensure functionality and reliability.


> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->