### PR TITLE
Add file-based sync trigger

### DIFF
--- a/ai-service/sync-watcher.js
+++ b/ai-service/sync-watcher.js
@@ -1,24 +1,38 @@
 const { syncMemory } = require('./cloud-sync');
 
-function startSyncWatcher(url, {
-  interval = 60000,
-  file = 'memory.json',
-  fetchFn = fetch,
-  syncFn = syncMemory,
-  setTimer = setInterval,
-  clearTimer = clearInterval,
-} = {}) {
+const fs = require('fs');
+
+function startSyncWatcher(
+  url,
+  {
+    interval = 60000,
+    file = 'memory.json',
+    fetchFn = fetch,
+    syncFn = syncMemory,
+    setTimer = setInterval,
+    clearTimer = clearInterval,
+    watchFile = fs.watchFile,
+    unwatchFile = fs.unwatchFile,
+  } = {}
+) {
+  let running = false;
   async function run() {
+    if (running) return;
+    running = true;
     try {
       await syncFn(url, file, fetchFn);
     } catch (err) {
       console.error('sync error:', err.message);
+    } finally {
+      running = false;
     }
   }
   const id = setTimer(run, interval);
+  watchFile(file, { persistent: false }, run);
   return {
     stop() {
       clearTimer(id);
+      unwatchFile(file, run);
     },
   };
 }

--- a/test/ai-service/sync-watcher.test.js
+++ b/test/ai-service/sync-watcher.test.js
@@ -29,6 +29,32 @@ describe('sync watcher', () => {
     expect(clearedId).to.equal(timerIds[0]);
   });
 
+  it('watches file for changes', async () => {
+    let watchCb;
+    let unwatchArg;
+    const watcher = startSyncWatcher('u', {
+      interval: 5,
+      syncFn: async () => {
+        watchCb.called = true;
+      },
+      setTimer: () => 1,
+      clearTimer: () => {},
+      watchFile: (f, _opts, cb) => {
+        watchCb = cb;
+        expect(f).to.equal('memory.json');
+      },
+      unwatchFile: (f) => {
+        unwatchArg = f;
+      },
+      fetchFn: async () => new Response('[]', { status: 200 })
+    });
+    watchCb.called = false;
+    await watchCb();
+    expect(watchCb.called).to.be.true;
+    watcher.stop();
+    expect(unwatchArg).to.equal('memory.json');
+  });
+
   it('swallows errors from sync', async () => {
     let fn;
     const watcher = startSyncWatcher('u', {


### PR DESCRIPTION
## Summary
- trigger cloud sync when memory file changes
- test new file-watch behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68446ab3cf708323ba2b21b7486956cb

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a file-based sync trigger to the `startSyncWatcher` function which monitors changes to a specified file and triggers synchronization whenever the file is modified.

### Why are these changes being made?

This change enables the system to respond to file changes in real-time by utilizing `fs.watchFile`, improving synchronization efficiency and timeliness beyond predefined intervals, which is especially useful for dynamic data that may change independently of the existing time-triggered sync cycle. This approach leverages the file system's ability to detect changes, which helps ensure that updates are not missed between sync intervals.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->