### PR TITLE
Add theme toggle with icon support

### DIFF
--- a/app/src/index.html
+++ b/app/src/index.html
@@ -4,6 +4,16 @@
     <meta charset="utf-8" />
     <title>Monaco Editor</title>
     <style>
+      :root {
+        --bg-color: #121212;
+        --text-color: #eee;
+        --bar-bg: #222;
+      }
+      body.light {
+        --bg-color: #fff;
+        --text-color: #000;
+        --bar-bg: #eee;
+      }
       html,
       body {
         height: 100%;
@@ -12,6 +22,8 @@
       body {
         display: flex;
         flex-direction: column;
+        background: var(--bg-color);
+        color: var(--text-color);
       }
       #main {
         flex: 1;
@@ -48,11 +60,7 @@
     </div>
     <div
       id="chat-bar"
-      style="
-        background: #222;
-        color: #eee;
-        padding: 4px;
-      "
+      style="background: var(--bar-bg); color: var(--text-color); padding: 4px"
     >
       <input
         id="chat-input"
@@ -61,8 +69,11 @@
       />
       <button id="chat-send">Send</button>
       <button id="voice-btn">Voice</button>
+      <button id="theme-toggle">Light</button>
       <pre id="chat-output" style="white-space: pre-wrap"></pre>
     </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/feather-icons/dist/feather.min.js"></script>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.44.0/min/vs/loader.min.js"></script>
     <script>
@@ -80,6 +91,9 @@
         );
         enableInlineCompletion(editor);
         setupUI(document, editor);
+        try {
+          if (window.feather) window.feather.replace();
+        } catch {}
       });
     </script>
   </body>

--- a/app/ui.js
+++ b/app/ui.js
@@ -65,7 +65,9 @@ function setupUI(
   if (patchInput && applyBtn && diffEl) {
     const updateDiff = () => {
       try {
-        const { original, patched } = (preview || previewPatch)(patchInput.value);
+        const { original, patched } = (preview || previewPatch)(
+          patchInput.value
+        );
         const mon = monacoLib || require('monaco-editor');
         if (!diffEditor) {
           diffEditor = mon.editor.createDiffEditor(diffEl, { readOnly: true });
@@ -88,6 +90,31 @@ function setupUI(
       } catch (err) {
         if (typeof alert !== 'undefined') alert(err.message);
       }
+    };
+  }
+
+  const themeBtn = doc.getElementById('theme-toggle');
+  if (themeBtn) {
+    const applyTheme = (theme) => {
+      doc.body.classList.remove('light', 'dark');
+      doc.body.classList.add(theme);
+      try {
+        if (doc.defaultView && doc.defaultView.localStorage) {
+          doc.defaultView.localStorage.setItem('theme', theme);
+        }
+      } catch {}
+      themeBtn.textContent = theme === 'dark' ? 'Light' : 'Dark';
+    };
+    let theme = 'dark';
+    try {
+      if (doc.defaultView && doc.defaultView.localStorage) {
+        theme = doc.defaultView.localStorage.getItem('theme') || 'dark';
+      }
+    } catch {}
+    applyTheme(theme);
+    themeBtn.onclick = () => {
+      const next = doc.body.classList.contains('dark') ? 'light' : 'dark';
+      applyTheme(next);
     };
   }
 }

--- a/test/app/ui.test.js
+++ b/test/app/ui.test.js
@@ -4,8 +4,8 @@ const { setupUI } = require('../../app/ui');
 
 describe('UI integration', () => {
   function createDom() {
-    const html = `<!DOCTYPE html><div id="container"></div><input id="chat-input"><button id="chat-send">Send</button><button id="voice-btn">Voice</button><pre id="chat-output"></pre>`;
-    const dom = new JSDOM(html);
+    const html = `<!DOCTYPE html><div id="container"></div><input id="chat-input"><button id="chat-send">Send</button><button id="voice-btn">Voice</button><button id="theme-toggle">Light</button><pre id="chat-output"></pre>`;
+    const dom = new JSDOM(html, { url: 'http://localhost' });
     return dom.window.document;
   }
 
@@ -73,7 +73,11 @@ describe('UI integration', () => {
         createVoiceCoder: () => ({ start() {}, stop() {} }),
         startSyncWatcher: (url, opts) => {
           args = `${url}|${opts.file}`;
-          return { stop: () => { stopped = true; } };
+          return {
+            stop: () => {
+              stopped = true;
+            },
+          };
         },
       }
     );
@@ -82,5 +86,23 @@ describe('UI integration', () => {
     expect(stopped).to.be.true;
     delete process.env.MEMORY_SYNC_URL;
     delete process.env.MEMORY_FILE;
+  });
+
+  it('toggles theme on button click', () => {
+    const doc = createDom();
+    setupUI(
+      doc,
+      {},
+      {
+        runChat: async () => {},
+        createVoiceCoder: () => ({ start() {}, stop() {} }),
+      }
+    );
+    const btn = doc.getElementById('theme-toggle');
+    expect(doc.body.classList.contains('dark')).to.be.true;
+    btn.onclick();
+    expect(doc.body.classList.contains('light')).to.be.true;
+    btn.onclick();
+    expect(doc.body.classList.contains('dark')).to.be.true;
   });
 });


### PR DESCRIPTION
## Summary
- add theme variables and switcher button
- apply theme persistence via localStorage
- update UI script to handle theme toggle and icons
- test the new theme toggle behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844745b42a48323be901cf83dd6e2ed

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a theme toggle button with icon support to the application, allowing users to switch between light and dark themes, and persist their choice using local storage.

### Why are these changes being made?

These changes address user requests for adjustable theme settings, improving usability by providing a customizable interface. The approach leverages CSS variables for an efficient theme change and integrates icon support to enhance the UI, maintaining user preferences with local storage for a consistent experience across sessions.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->