### PR TITLE
Implement built-in shell module

### DIFF
--- a/agent/shell.js
+++ b/agent/shell.js
@@ -1,0 +1,13 @@
+const { spawn } = require('child_process');
+
+function openShell({
+  cwd = '.',
+  shell = process.env.SHELL,
+  args = [],
+  spawnImpl = spawn,
+} = {}) {
+  if (!shell) shell = process.platform === 'win32' ? 'cmd.exe' : 'bash';
+  return spawnImpl(shell, args, { cwd, stdio: 'inherit', shell: false });
+}
+
+module.exports = { openShell };

--- a/test/agent/shell.test.js
+++ b/test/agent/shell.test.js
@@ -1,0 +1,36 @@
+const { expect } = require('chai');
+const { openShell } = require('../../agent/shell');
+
+describe('openShell', () => {
+  it('spawns provided shell with args and options', () => {
+    let called;
+    const spawnImpl = (cmd, args, opts) => {
+      called = { cmd, args, opts };
+      return { pid: 1 };
+    };
+    const child = openShell({
+      cwd: '/tmp',
+      shell: '/bin/zsh',
+      args: ['-l'],
+      spawnImpl,
+    });
+    expect(called).to.deep.equal({
+      cmd: '/bin/zsh',
+      args: ['-l'],
+      opts: { cwd: '/tmp', stdio: 'inherit', shell: false },
+    });
+    expect(child.pid).to.equal(1);
+  });
+
+  it('falls back to default shell', () => {
+    let cmd;
+    const spawnImpl = (c) => {
+      cmd = c;
+      return {};
+    };
+    delete process.env.SHELL;
+    const expected = process.platform === 'win32' ? 'cmd.exe' : 'bash';
+    openShell({ spawnImpl });
+    expect(cmd).to.equal(expected);
+  });
+});


### PR DESCRIPTION
## Summary
- add `openShell` helper for launching an interactive shell
- test shell behaviour

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684476aeced48323832982b84212c237


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.
