### PR TITLE
Add reasoning log with approval prompt

### DIFF
--- a/agent/reasoning-log.js
+++ b/agent/reasoning-log.js
@@ -1,0 +1,31 @@
+const fs = require('fs');
+const readline = require('readline');
+
+function defaultPrompt(question) {
+  return new Promise((resolve) => {
+    const rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout,
+    });
+    rl.question(question, (answer) => {
+      rl.close();
+      resolve(answer);
+    });
+  });
+}
+
+function createLogger({ file = 'reasoning.log', prompt = defaultPrompt } = {}) {
+  function log(message) {
+    fs.appendFileSync(file, message + '\n');
+  }
+
+  async function approve() {
+    const content = fs.existsSync(file) ? fs.readFileSync(file, 'utf8') : '';
+    const answer = await prompt(`${content}\nApply changes? (y/N) `);
+    return /^y(es)?$/i.test(answer.trim());
+  }
+
+  return { log, approve };
+}
+
+module.exports = { createLogger };

--- a/test/agent/reasoning-log.test.js
+++ b/test/agent/reasoning-log.test.js
@@ -1,0 +1,38 @@
+const { expect } = require('chai');
+const fs = require('fs');
+const os = require('os');
+const { join } = require('path');
+const { createLogger } = require('../../agent/reasoning-log');
+
+describe('reasoning log', () => {
+  it('appends messages to log file', () => {
+    const file = join(os.tmpdir(), `log-${Date.now()}`);
+    const { log } = createLogger({ file, prompt: async () => 'n' });
+    log('step 1');
+    log('step 2');
+    const content = fs.readFileSync(file, 'utf8').trim();
+    expect(content).to.equal('step 1\nstep 2');
+  });
+
+  it('returns true when approved', async () => {
+    const file = join(os.tmpdir(), `log-${Date.now()}`);
+    let asked = '';
+    const prompt = async (q) => {
+      asked = q;
+      return 'y';
+    };
+    const { log, approve } = createLogger({ file, prompt });
+    log('do it');
+    const ok = await approve();
+    expect(asked).to.match(/Apply changes/);
+    expect(ok).to.equal(true);
+  });
+
+  it('returns false when rejected', async () => {
+    const file = join(os.tmpdir(), `log-${Date.now()}`);
+    const { log, approve } = createLogger({ file, prompt: async () => 'n' });
+    log('no');
+    const ok = await approve();
+    expect(ok).to.equal(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add `reasoning-log` module for logging agent steps
- ask user for approval based on the log
- test logging and approval behaviour

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68447c8e4a58832398a78d3bff9753eb


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.
