### PR TITLE
Implement modern icon buttons

### DIFF
--- a/app/src/index.html
+++ b/app/src/index.html
@@ -49,7 +49,9 @@
     <div id="main">
       <div id="patch-pane">
         <textarea id="patch-input" placeholder="Patch text"></textarea>
-        <button id="apply-patch">Apply Patch</button>
+        <button id="apply-patch">
+          <i data-feather="check-square"></i><span>Apply Patch</span>
+        </button>
       </div>
       <div id="editor-pane">
         <div id="container"></div>
@@ -67,9 +69,11 @@
         style="width: 70%"
         placeholder="Ask the assistant"
       />
-      <button id="chat-send">Send</button>
-      <button id="voice-btn">Voice</button>
-      <button id="theme-toggle">Light</button>
+      <button id="chat-send"><i data-feather="send"></i></button>
+      <button id="voice-btn">
+        <i data-feather="mic"></i><span>Voice</span>
+      </button>
+      <button id="theme-toggle"><i data-feather="sun"></i></button>
       <pre id="chat-output" style="white-space: pre-wrap"></pre>
     </div>
 

--- a/app/ui.js
+++ b/app/ui.js
@@ -25,19 +25,21 @@ function setupUI(
     }
   }
   let voice;
-  doc.getElementById('voice-btn').onclick = () => {
+  const voiceBtn = doc.getElementById('voice-btn');
+  const voiceLabel = voiceBtn.querySelector('span') || voiceBtn;
+  voiceBtn.onclick = () => {
     if (!voice) {
       try {
         voice = voiceCtor(editor);
         voice.start();
-        doc.getElementById('voice-btn').textContent = 'Stop';
+        voiceLabel.textContent = 'Stop';
       } catch (err) {
         if (typeof alert !== 'undefined') alert(err.message);
       }
     } else {
       voice.stop();
       voice = null;
-      doc.getElementById('voice-btn').textContent = 'Voice';
+      voiceLabel.textContent = 'Voice';
     }
   };
 
@@ -95,6 +97,7 @@ function setupUI(
 
   const themeBtn = doc.getElementById('theme-toggle');
   if (themeBtn) {
+    const themeIcon = themeBtn.querySelector('i');
     const applyTheme = (theme) => {
       doc.body.classList.remove('light', 'dark');
       doc.body.classList.add(theme);
@@ -103,7 +106,17 @@ function setupUI(
           doc.defaultView.localStorage.setItem('theme', theme);
         }
       } catch {}
-      themeBtn.textContent = theme === 'dark' ? 'Light' : 'Dark';
+      if (themeIcon) {
+        themeIcon.setAttribute(
+          'data-feather',
+          theme === 'dark' ? 'sun' : 'moon'
+        );
+        try {
+          if (doc.defaultView && doc.defaultView.feather) {
+            doc.defaultView.feather.replace();
+          }
+        } catch {}
+      }
     };
     let theme = 'dark';
     try {

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -48,7 +48,7 @@ This document outlines the proposed plan for developing the AI IDE.
 
 ## Next Steps
 
-- 3-pane layout with diff viewer and one-click patch apply
+- 3-pane layout with diff viewer and one-click patch apply ✅
 - Light and dark themes with modern icons
 - Model flexibility via status bar switcher
 - Windows installer auto-update and winget manifest


### PR DESCRIPTION
## Summary
- mark three-pane diff UI as complete in the roadmap
- enhance the editor UI with Feather icons
- keep voice button icon while toggling text
- switch theme button icon between sun and moon

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68447e3b337c8323acc72a67e9ce2bc0