### PR TITLE
Add model switcher in status bar

### DIFF
--- a/app/autocomplete.js
+++ b/app/autocomplete.js
@@ -1,5 +1,6 @@
 const { streamChatCompletion } = require('../ai-service/openrouter');
 const { runLlama } = require('../ai-service/llama');
+const { getModel } = require('./model');
 
 async function fetchCompletion(
   prefix,
@@ -14,7 +15,7 @@ async function fetchCompletion(
     let result = '';
     for await (const chunk of stream({
       messages,
-      models: ['openrouter/openai/gpt-3.5-turbo'],
+      models: [getModel()],
       apiKey,
     })) {
       const content = chunk.choices?.[0]?.delta?.content;

--- a/app/chat.js
+++ b/app/chat.js
@@ -1,5 +1,6 @@
 const { streamChatCompletion } = require('../ai-service/openrouter');
 const { runLlama } = require('../ai-service/llama');
+const { getModel } = require('./model');
 
 async function runChat(
   messages,
@@ -13,7 +14,7 @@ async function runChat(
   if (apiKey) {
     for await (const chunk of stream({
       messages,
-      models: ['openrouter/openai/gpt-3.5-turbo'],
+      models: [getModel()],
       apiKey,
     })) {
       const content = chunk.choices?.[0]?.delta?.content;

--- a/app/model.js
+++ b/app/model.js
@@ -1,0 +1,13 @@
+let currentModel = 'openrouter/openai/gpt-3.5-turbo';
+
+function setModel(model) {
+  if (typeof model === 'string' && model.trim()) {
+    currentModel = model;
+  }
+}
+
+function getModel() {
+  return currentModel;
+}
+
+module.exports = { setModel, getModel };

--- a/app/src/index.html
+++ b/app/src/index.html
@@ -43,6 +43,9 @@
       #patch-input {
         flex: 1;
       }
+      #model-switcher {
+        margin: 0 4px;
+      }
     </style>
   </head>
   <body>
@@ -73,6 +76,10 @@
       <button id="voice-btn">
         <i data-feather="mic"></i><span>Voice</span>
       </button>
+      <select id="model-switcher">
+        <option value="openrouter/openai/gpt-3.5-turbo">gpt-3.5</option>
+        <option value="openrouter/openai/gpt-4">gpt-4</option>
+      </select>
       <button id="theme-toggle"><i data-feather="sun"></i></button>
       <pre id="chat-output" style="white-space: pre-wrap"></pre>
     </div>

--- a/app/ui.js
+++ b/app/ui.js
@@ -2,6 +2,7 @@ const { runChatWithMemory } = require('./chat-memory');
 const { createVoiceCoder } = require('./voice');
 const { startSyncWatcher } = require('../ai-service/sync-watcher');
 const { previewPatch, applyPatch } = require('./patcher');
+const { setModel, getModel } = require('./model');
 
 function setupUI(
   doc,
@@ -13,6 +14,8 @@ function setupUI(
     previewPatch: preview = previewPatch,
     applyPatch: applyFn = applyPatch,
     monaco: monacoLib,
+    setModel: setModelFn = setModel,
+    getModel: getModelFn = getModel,
   } = {}
 ) {
   let watcher;
@@ -93,6 +96,27 @@ function setupUI(
         if (typeof alert !== 'undefined') alert(err.message);
       }
     };
+  }
+
+  const modelSelect = doc.getElementById('model-switcher');
+  if (modelSelect) {
+    const applyModel = (model) => {
+      setModelFn(model);
+      try {
+        if (doc.defaultView && doc.defaultView.localStorage) {
+          doc.defaultView.localStorage.setItem('model', model);
+        }
+      } catch {}
+    };
+    let model = getModelFn();
+    try {
+      if (doc.defaultView && doc.defaultView.localStorage) {
+        model = doc.defaultView.localStorage.getItem('model') || model;
+      }
+    } catch {}
+    modelSelect.value = model;
+    applyModel(model);
+    modelSelect.onchange = () => applyModel(modelSelect.value);
   }
 
   const themeBtn = doc.getElementById('theme-toggle');

--- a/test/app/autocomplete.test.js
+++ b/test/app/autocomplete.test.js
@@ -1,5 +1,6 @@
 const { expect } = require('chai');
 const { fetchCompletion } = require('../../app/autocomplete');
+const { setModel } = require('../../app/model');
 
 function mockStream(chunks) {
   return (async function* () {
@@ -42,5 +43,18 @@ describe('fetchCompletion', () => {
       runLlama: async () => 'local',
     });
     expect(result).to.equal('local');
+  });
+
+  it('uses selected model for OpenRouter', async () => {
+    process.env.OPENROUTER_API_KEY = 'test';
+    setModel('x');
+    let used;
+    await fetchCompletion('foo', {
+      streamChatCompletion: ({ models }) => {
+        used = models[0];
+        return mockStream(['ok']);
+      },
+    });
+    expect(used).to.equal('x');
   });
 });

--- a/test/app/chat.test.js
+++ b/test/app/chat.test.js
@@ -1,5 +1,6 @@
 const { expect } = require('chai');
 const { runChat } = require('../../app/chat');
+const { setModel } = require('../../app/model');
 
 function mockStream(chunks) {
   return (async function* () {
@@ -44,5 +45,18 @@ describe('runChat', () => {
       runLlama: async () => 'local',
     });
     expect(received.join('')).to.equal('local');
+  });
+
+  it('uses selected model for OpenRouter', async () => {
+    process.env.OPENROUTER_API_KEY = 'test';
+    setModel('my-model');
+    let used;
+    await runChat([{ role: 'user', content: 'hi' }], () => {}, {
+      streamChatCompletion: ({ models }) => {
+        used = models[0];
+        return mockStream([]);
+      },
+    });
+    expect(used).to.equal('my-model');
   });
 });

--- a/test/app/ui.test.js
+++ b/test/app/ui.test.js
@@ -4,7 +4,7 @@ const { setupUI } = require('../../app/ui');
 
 describe('UI integration', () => {
   function createDom() {
-    const html = `<!DOCTYPE html><div id="container"></div><input id="chat-input"><button id="chat-send">Send</button><button id="voice-btn">Voice</button><button id="theme-toggle">Light</button><pre id="chat-output"></pre>`;
+    const html = `<!DOCTYPE html><div id="container"></div><input id="chat-input"><button id="chat-send">Send</button><button id="voice-btn">Voice</button><select id="model-switcher"><option value="a">a</option><option value="b">b</option></select><button id="theme-toggle">Light</button><pre id="chat-output"></pre>`;
     const dom = new JSDOM(html, { url: 'http://localhost' });
     return dom.window.document;
   }
@@ -104,5 +104,26 @@ describe('UI integration', () => {
     expect(doc.body.classList.contains('light')).to.be.true;
     btn.onclick();
     expect(doc.body.classList.contains('dark')).to.be.true;
+  });
+
+  it('changes model on selection', () => {
+    const doc = createDom();
+    let selected;
+    setupUI(
+      doc,
+      {},
+      {
+        runChat: async () => {},
+        createVoiceCoder: () => ({ start() {}, stop() {} }),
+        setModel: (m) => {
+          selected = m;
+        },
+        getModel: () => 'a',
+      }
+    );
+    const sel = doc.getElementById('model-switcher');
+    sel.value = 'b';
+    sel.onchange();
+    expect(selected).to.equal('b');
   });
 });


### PR DESCRIPTION
## Summary
- implement model switcher to choose OpenRouter model
- store selection with `app/model` module
- hook model selector into UI and persist via localStorage
- update chat and autocomplete to respect chosen model
- expand tests for new functionality

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844817888308323b89bdf43ab4a5cc6

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a model switcher in the status bar allowing users to select different models for chat operations, and refactor code to use the selected model throughout the application.

### Why are these changes being made?

This change is being implemented to provide users with the flexibility to select from multiple AI models during their sessions, enhancing the user experience. The inclusion of a model switcher in the UI coupled with persistent model selection through local storage represents the best approach to maintaining user preferences across sessions efficiently.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->