### PR TITLE
Add monetization plan to roadmap

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -59,3 +59,54 @@ This document outlines the proposed plan for developing the AI IDE.
 - Continued polish of the mobile UI
 - Packaging and installers for each platform
 - Enhanced GPU offloading options
+
+## Monetization Plan
+
+### Short answer
+
+Yes — launch it free but tell users from day one that paid tiers are coming. That gives you instant onboarding data without locking you into a forever-free expectation.
+
+### Why "free-first, pay-later" can work
+
+| Benefit | How it helps now |
+| --- | --- |
+| Accelerates user feedback | A friction-free sign-up means more testers → more bug reports and feature requests before you harden pricing. |
+| Builds social proof | Stars, testimonials, Discord chatter, case-study threads — all easier when there’s no paywall. |
+| Reduces churn risk | You can watch real-world behaviour, then design pricing around what users actually do (seats, tokens, projects, etc.). |
+| Signals goodwill | Early adopters feel like partners, not just customers, if they get to "kick the tyres" first. |
+
+### But avoid the two common traps
+
+1. **Surprise paywall backlash**
+   - State in the README, landing page, and onboarding email:
+     "Alex-2.0 is in open beta. Core features are free today; paid plans roll out Q4 2025."
+     This sets expectations and lets people budget.
+2. **Unlimited cost bleed**
+   - Free users can rack up LLM or GPU bills. Put hard guard-rails early:
+     - daily token cap
+     - rate limits
+     - or only local-model inference during beta.
+
+### A phased plan that keeps everyone happy
+
+| Phase | What users get | What you learn | Duration |
+| --- | --- | --- | --- |
+| Public beta (free) | Full feature set but usage-capped; Slack/Discord support. | Core feature adoption, cost curve, bug surface. | 4-8 weeks |
+| Founders’ discount | Lock-in offer: "$99/year for life" if they subscribe before GA. | Price-sensitivity signal and early revenue. | 2-3 weeks overlap with beta |
+| General Availability | Free tier (token/seat-limited) + Pro/Team paid tiers. | Stable MRR, growth funnels. | Long-term |
+
+### Tactical checklist
+
+- Add a banner inside the app: "Beta — paid plans coming; see roadmap."
+- Set hard limits (env vars) for GPT/Claude calls; cut off politely with a "hit limit, try tomorrow" message.
+- Collect metrics:
+  - active days per user
+  - prompts per project
+  - model cost per user
+  Those numbers shape pricing.
+- Prepare Stripe now (test mode). When you flip the switch, it’s just changing the publishable key.
+- Grandfather early adopters: free tier stays usable for personal projects so nobody feels bait-and-switched.
+
+### Bottom line
+
+Launch open + free, but be loud and clear that it’s an introductory beta. Set usage caps so costs don’t spiral, watch how people use the product, then roll out subscriptions with a founders’ deal to convert your biggest fans.


### PR DESCRIPTION
## Summary
- outline free-first beta in `docs/ROADMAP.md`

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844851ef6a48323aa8abc42b3cc425b

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a detailed monetization plan to the roadmap documentation to specify the transition from a free beta phase to a paid tier model.

### Why are these changes being made?

The changes provide a clear strategy for introducing monetized tiers, helping to establish user expectations from day one, while gathering valuable feedback and usage data during the free beta phase. This structured approach aims to minimize customer churn, build goodwill, and set the stage for sustainable revenue growth through well-informed pricing models.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->