### PR TITLE
Add architecture diagram and contributing guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ You can also run the commands individually if preferred.
 
 ## Architecture
 
-The current structure is intentionally lightweight. It includes only a README file, but you can expand it with your own scripts or additional resources. Feel free to adapt the layout to suit your needs.
+The codebase is intentionally lightweight. See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for a high-level diagram of how the pieces interact. You can extend the structure with your own scripts or additional resources.
 
 ## Real-time Editing Demo
 
@@ -194,7 +194,7 @@ chat history after each message.
 
 ## Contributing
 
-Contributions are welcome! Fork the repository, create a new branch for your feature or bug fix, and submit a pull request. Please keep your commits concise and provide clear descriptions of your changes.
+Contributions are welcome! Fork the repository, create a new branch for your feature or bug fix, and submit a pull request. Please keep your commits concise and provide clear descriptions of your changes. For more details, see [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md).
 
 ## Working with Binary Files
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,23 @@
+# Architecture
+
+The project uses an Electron shell with a web-based renderer. The renderer hosts the Monaco editor and communicates with the Node.js main process via IPC. OpenRouter or a local `llama.cpp` binary provides completions. Chat history is stored on disk and can be synced to a remote service.
+
+```mermaid
+graph TD
+    subgraph Renderer
+        A[Monaco Editor]
+        B[Voice Coder]
+    end
+    subgraph Main
+        C[Electron Main]
+        D[OpenRouter / Llama]
+        E[Memory Store]
+    end
+    A -->|Yjs| F[WebRTC Peers]
+    B --> A
+    A -- IPC --> C
+    C --> D
+    C --> E
+    E <-->|HTTP| G[Cloud Sync]
+``` 
+

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,13 @@
+# Contributing Guide
+
+Thank you for considering a contribution! Please follow these steps to get started:
+
+1. **Fork the repo** on GitHub and create a feature branch.
+2. **Install dependencies** using `npm install` and `cd app && npm install`.
+3. **Run the tests** with `npm test` to ensure everything passes.
+4. Make your changes with clear commits.
+5. Open a pull request targeting the `main` branch. Include a summary of your changes.
+
+We use [Mocha](https://mochajs.org/) for the test suite and [ESLint](https://eslint.org/) for linting. Run `npm run lint` and `npm test` before submitting your PR.
+
+See [ARCHITECTURE.md](ARCHITECTURE.md) for an overview of how the pieces fit together.


### PR DESCRIPTION
## Summary
- document a high-level architecture diagram
- add a contributing guide and reference it from README
- link to architecture doc from README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684485f396808323a59fb42d73ec89d2