### PR TITLE
Implement telemetry dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,14 @@ Each OpenRouter request can include `usage` tracking to report token counts and 
 The `cost-dashboard` module aggregates these usage objects and exposes the total
 credits consumed during a session.
 
+## Telemetry Dashboard
+
+Use `telemetry-dashboard.js` to log events across the app. Call
+`recordEvent(type, data)` to store an event with a timestamp. When the `type` is
+`"usage"`, the event is also recorded by the cost dashboard so total spending is
+tracked automatically. Retrieve the list with `getEvents()` or aggregate counts
+with `getEventCounts()`.
+
 ## Persistent Memory Store
 
 Use `memory-store.js` to persist conversation history between sessions. The

--- a/ai-service/telemetry-dashboard.js
+++ b/ai-service/telemetry-dashboard.js
@@ -1,0 +1,42 @@
+const { recordUsage, getTotalCost, getHistory, reset: resetCost } = require('./cost-dashboard');
+
+const events = [];
+
+/**
+ * Record a telemetry event.
+ * If the event type is 'usage', the data is also passed to the cost dashboard.
+ * @param {string} type - Event type name
+ * @param {object} [data] - Optional data payload
+ */
+function recordEvent(type, data = {}) {
+  if (type === 'usage') {
+    recordUsage(data);
+  }
+  events.push({ type, data, time: Date.now() });
+}
+
+function getEvents() {
+  return events.slice();
+}
+
+function getEventCounts() {
+  const counts = {};
+  for (const e of events) {
+    counts[e.type] = (counts[e.type] || 0) + 1;
+  }
+  return counts;
+}
+
+function reset() {
+  events.length = 0;
+  resetCost();
+}
+
+module.exports = {
+  recordEvent,
+  getEvents,
+  getEventCounts,
+  getTotalCost,
+  getHistory,
+  reset,
+};

--- a/test/ai-service/telemetry-dashboard.test.js
+++ b/test/ai-service/telemetry-dashboard.test.js
@@ -1,0 +1,28 @@
+const { expect } = require('chai');
+const {
+  recordEvent,
+  getEvents,
+  getEventCounts,
+  getTotalCost,
+  getHistory,
+  reset,
+} = require('../../ai-service/telemetry-dashboard');
+
+describe('telemetry dashboard', () => {
+  afterEach(() => reset());
+
+  it('records events and counts them', () => {
+    recordEvent('start');
+    recordEvent('start');
+    recordEvent('stop');
+    expect(getEvents()).to.have.length(3);
+    expect(getEventCounts()).to.deep.equal({ start: 2, stop: 1 });
+  });
+
+  it('tracks usage cost via cost dashboard', () => {
+    recordEvent('usage', { cost: 1 });
+    recordEvent('usage', { cost: 2 });
+    expect(getTotalCost()).to.equal(3);
+    expect(getHistory()).to.deep.equal([{ cost: 1 }, { cost: 2 }]);
+  });
+});


### PR DESCRIPTION
## Summary
- add telemetry-dashboard for event logging and cost tracking
- document telemetry dashboard in README
- test telemetry-dashboard

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844871f87608323a9d92c5b42c062a7