### PR TITLE
Add telemetry reporting to chatops CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,12 @@ Search code for a word:
 node cli/chatops.js search TODO src
 ```
 
+View telemetry event counts and total cost:
+
+```bash
+node cli/chatops.js telemetry
+```
+
 ## Cloud Sync Watcher
 
 Automatically keep your memory file in sync across devices. Use

--- a/cli/chatops.js
+++ b/cli/chatops.js
@@ -7,6 +7,10 @@ const {
 } = require('../ai-service/cloud-sync');
 const { startSyncWatcher } = require('../ai-service/sync-watcher');
 const { createIndex, search: searchIdx } = require('../search/indexer');
+const {
+  getEventCounts,
+  getTotalCost,
+} = require('../ai-service/telemetry-dashboard');
 
 async function main(
   argv = process.argv.slice(2),
@@ -18,6 +22,8 @@ async function main(
     watchFn = startSyncWatcher,
     indexFn = createIndex,
     searchFn = searchIdx,
+    eventCountsFn = getEventCounts,
+    costFn = getTotalCost,
   } = {}
 ) {
   const [cmd, ...args] = argv;
@@ -119,8 +125,17 @@ async function main(
       return 1;
     }
   }
+  if (cmd === 'telemetry') {
+    const counts = eventCountsFn();
+    const total = costFn();
+    for (const [type, count] of Object.entries(counts)) {
+      console.log(`${type}: ${count}`);
+    }
+    console.log(`Total cost: ${total}`);
+    return 0;
+  }
   console.error('Usage: chatops <command> [args...]');
-  console.error('Commands: plan, sync, upload, download, watch, search');
+  console.error('Commands: plan, sync, upload, download, watch, search, telemetry');
   return 1;
 }
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -52,7 +52,7 @@ This document outlines the proposed plan for developing the AI IDE.
 - Light and dark themes with modern icons ✅
 - Model flexibility via status bar switcher ✅
 - Windows installer auto-update and winget manifest ✅
-- Telemetry dashboard and cost tracking
+- Telemetry dashboard and cost tracking ✅
 - Sample extension and model plugin
 - Architecture diagram and contribution guide
 - Demo GIFs and screenshots of core flows

--- a/test/cli/chatops.test.js
+++ b/test/cli/chatops.test.js
@@ -102,6 +102,24 @@ describe('chatops CLI', () => {
     expect(code).to.equal(0);
   });
 
+  it('shows telemetry info', async () => {
+    let printed = [];
+    const oldLog = console.log;
+    console.log = (msg) => printed.push(msg);
+    const code = await main(['telemetry'], {
+      eventCountsFn: () => ({ start: 2 }),
+      costFn: () => 1.5,
+      planFn: async () => {},
+      syncFn: async () => {},
+      uploadFn: async () => {},
+      downloadFn: async () => {},
+      watchFn: async () => {},
+    });
+    console.log = oldLog;
+    expect(printed).to.deep.equal(['start: 2', 'Total cost: 1.5']);
+    expect(code).to.equal(0);
+  });
+
   it('returns error on unknown command', async () => {
     const code = await main(['unknown'], {
       planFn: async () => {},


### PR DESCRIPTION
## Summary
- add telemetry reporting option to `chatops`
- document the new command in README
- mark roadmap item as complete
- test telemetry command

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684489ed56088323b88d87c68fef2a56