### PR TITLE
Implement test runner and shell commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,18 @@ Search code for a word:
 node cli/chatops.js search TODO src
 ```
 
+Launch an interactive shell in the project directory:
+
+```bash
+node cli/chatops.js shell
+```
+
+Run the test suite with optional retries:
+
+```bash
+node cli/chatops.js test 2
+```
+
 View telemetry event counts and total cost:
 
 ```bash

--- a/cli/chatops.js
+++ b/cli/chatops.js
@@ -11,6 +11,8 @@ const {
   getEventCounts,
   getTotalCost,
 } = require('../ai-service/telemetry-dashboard');
+const { openShell } = require('../agent/shell');
+const { runTests } = require('../agent/test-runner');
 
 async function main(
   argv = process.argv.slice(2),
@@ -24,6 +26,8 @@ async function main(
     searchFn = searchIdx,
     eventCountsFn = getEventCounts,
     costFn = getTotalCost,
+    shellFn = openShell,
+    testFn = runTests,
   } = {}
 ) {
   const [cmd, ...args] = argv;
@@ -125,6 +129,20 @@ async function main(
       return 1;
     }
   }
+  if (cmd === 'shell') {
+    shellFn();
+    return 0;
+  }
+  if (cmd === 'test') {
+    const retries = parseInt(args[0] || '0', 10);
+    try {
+      testFn({ retries });
+      return 0;
+    } catch (err) {
+      console.error(err.message);
+      return 1;
+    }
+  }
   if (cmd === 'telemetry') {
     const counts = eventCountsFn();
     const total = costFn();
@@ -135,7 +153,9 @@ async function main(
     return 0;
   }
   console.error('Usage: chatops <command> [args...]');
-  console.error('Commands: plan, sync, upload, download, watch, search, telemetry');
+  console.error(
+    'Commands: plan, sync, upload, download, watch, search, shell, test, telemetry'
+  );
   return 1;
 }
 

--- a/test/cli/chatops.test.js
+++ b/test/cli/chatops.test.js
@@ -102,6 +102,55 @@ describe('chatops CLI', () => {
     expect(code).to.equal(0);
   });
 
+  it('opens shell', async () => {
+    let called = false;
+    const code = await main(['shell'], {
+      shellFn: () => {
+        called = true;
+      },
+      planFn: async () => {},
+      syncFn: async () => {},
+      uploadFn: async () => {},
+      downloadFn: async () => {},
+      watchFn: async () => {},
+    });
+    expect(called).to.be.true;
+    expect(code).to.equal(0);
+  });
+
+  it('runs test command', async () => {
+    let retriesArg;
+    let called = false;
+    const code = await main(['test', '2'], {
+      testFn: ({ retries }) => {
+        retriesArg = retries;
+        called = true;
+      },
+      planFn: async () => {},
+      syncFn: async () => {},
+      uploadFn: async () => {},
+      downloadFn: async () => {},
+      watchFn: async () => {},
+    });
+    expect(called).to.be.true;
+    expect(retriesArg).to.equal(2);
+    expect(code).to.equal(0);
+  });
+
+  it('returns error when tests fail', async () => {
+    const code = await main(['test'], {
+      testFn: () => {
+        throw new Error('fail');
+      },
+      planFn: async () => {},
+      syncFn: async () => {},
+      uploadFn: async () => {},
+      downloadFn: async () => {},
+      watchFn: async () => {},
+    });
+    expect(code).to.equal(1);
+  });
+
   it('shows telemetry info', async () => {
     let printed = [];
     const oldLog = console.log;


### PR DESCRIPTION
## Summary
- add new `shell` and `test` commands to ChatOps CLI
- document usage of the new commands in README
- test CLI shell and test commands

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68448bf64ed88323adb3536f6e482803