### PR TITLE
Implement summarizer plugin

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -53,7 +53,7 @@ This document outlines the proposed plan for developing the AI IDE.
 - Model flexibility via status bar switcher ✅
 - Windows installer auto-update and winget manifest ✅
 - Telemetry dashboard and cost tracking ✅
-- Sample extension and model plugin
+- Sample extension and model plugin ✅
 - Architecture diagram and contribution guide
 - Demo GIFs and screenshots of core flows
 - Continued polish of the mobile UI

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -11,3 +11,14 @@ via `registerCommand(name, fn)` and execute them with `runCommand(name, ...args)
 
 Available extensions can be listed and installed using `marketplace.js`, which
 reads `marketplace.json` for plugin sources.
+
+## Example
+
+`summarizer.js` registers a `summarize` command that returns a one-sentence summary of the provided text. It uses the active OpenRouter model if an API key is set, otherwise it falls back to a local `llama.cpp` runner.
+
+```javascript
+const api = require('./api');
+const { loadPlugins } = require('./loader');
+loadPlugins(__dirname, api);
+api.runCommand('summarize', 'Hello world');
+```

--- a/plugins/summarizer.js
+++ b/plugins/summarizer.js
@@ -1,0 +1,44 @@
+const { streamChatCompletion } = require('../ai-service/openrouter');
+const { runLlama } = require('../ai-service/llama');
+const { getModel } = require('../app/model');
+
+async function summarize(
+  text,
+  {
+    streamChatCompletion: stream = streamChatCompletion,
+    runLlama: llama = runLlama,
+    getModel: getModelFn = getModel,
+  } = {}
+) {
+  const messages = [
+    { role: 'system', content: 'Summarize the following text in one sentence.' },
+    { role: 'user', content: text },
+  ];
+  const apiKey = process.env.OPENROUTER_API_KEY;
+  if (apiKey) {
+    let result = '';
+    for await (const chunk of stream({
+      messages,
+      models: [getModelFn()],
+      apiKey,
+    })) {
+      const content = chunk.choices?.[0]?.delta?.content;
+      if (content) result += content;
+    }
+    return result.trim();
+  }
+  if (process.env.LLAMA_PATH && process.env.LLAMA_MODEL) {
+    const prompt = messages.map((m) => m.content).join('\n');
+    return llama(prompt);
+  }
+  throw new Error('OPENROUTER_API_KEY is not set');
+}
+
+function activate(context = {}) {
+  const { registerCommand } = context;
+  if (registerCommand) {
+    registerCommand('summarize', summarize);
+  }
+}
+
+module.exports = { activate, summarize };

--- a/test/plugins/summarizer.test.js
+++ b/test/plugins/summarizer.test.js
@@ -1,0 +1,49 @@
+const { expect } = require('chai');
+const { summarize } = require('../../plugins/summarizer');
+
+function mockStream(chunks) {
+  return (async function* () {
+    for (const c of chunks) {
+      yield { choices: [{ delta: { content: c } }] };
+    }
+  })();
+}
+
+describe('summarizer plugin', () => {
+  afterEach(() => {
+    delete process.env.OPENROUTER_API_KEY;
+    delete process.env.LLAMA_PATH;
+    delete process.env.LLAMA_MODEL;
+  });
+
+  it('summarizes using OpenRouter', async () => {
+    process.env.OPENROUTER_API_KEY = 'key';
+    const text = await summarize('hello world', {
+      streamChatCompletion: () => mockStream(['sum']),
+      getModel: () => 'm',
+    });
+    expect(text).to.equal('sum');
+  });
+
+  it('falls back to local model when API key missing', async () => {
+    process.env.LLAMA_PATH = '/bin/llama';
+    process.env.LLAMA_MODEL = 'm.gguf';
+    const text = await summarize('hi', {
+      runLlama: async () => 'local',
+    });
+    expect(text).to.equal('local');
+  });
+
+  it('throws when no model configured', async () => {
+    let err;
+    try {
+      await summarize('foo', {
+        streamChatCompletion: () => mockStream([]),
+      });
+    } catch (e) {
+      err = e;
+    }
+    expect(err).to.be.instanceOf(Error);
+    expect(err.message).to.equal('OPENROUTER_API_KEY is not set');
+  });
+});


### PR DESCRIPTION
## Summary
- provide a new `summarizer` plugin that registers a `summarize` command
- document how to use the plugin in `plugins/README.md`
- tick off the roadmap item for sample extension and model plugin
- test the summarizer logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68448d7cdb6c832382a4b8831dba9b79